### PR TITLE
Remove @Public() decorator from findAll and findOne methods in Models…

### DIFF
--- a/src/modules/models/models.controller.ts
+++ b/src/modules/models/models.controller.ts
@@ -24,33 +24,33 @@ import { Public } from 'src/decorators/publicRoutes.decorator';
 @Controller('models')
 @ApiBearerAuth()
 @UseGuards(AuthGuard, RolesGuard)
-@Roles(Role.ADMIN)
 export class ModelsController {
   constructor(private readonly service: ModelsService) {}
 
   @Get()
-  @Public()
   findAll(): Promise<Model[]> {
     return this.service.findAll();
   }
 
   @Get(':id')
-  @Public()
   findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Model> {
     return this.service.findOne(id);
   }
 
   @Post()
+  @Roles(Role.ADMIN)
   create(@Body() dto: CreateModelDto): Promise<Model> {
     return this.service.create(dto);
   }
 
   @Put(':id')
+  @Roles(Role.ADMIN)
   update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateModelDto): Promise<Model> {
     return this.service.update(id, dto);
   }
 
   @Delete(':id')
+  @Roles(Role.ADMIN)
   delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.service.delete(id);
   }

--- a/src/modules/versions/versions.controller.ts
+++ b/src/modules/versions/versions.controller.ts
@@ -24,33 +24,33 @@ import { Public } from 'src/decorators/publicRoutes.decorator';
 @ApiBearerAuth()
 @Controller('versions')
 @UseGuards(AuthGuard, RolesGuard)
-@Roles(Role.ADMIN)
 export class VersionsController {
   constructor(private readonly service: VersionsService) {}
 
-  @Public()
   @Get()
   findAll(): Promise<Version[]> {
     return this.service.findAll();
   }
 
-  @Public()
   @Get(':id')
   findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Version> {
     return this.service.findOne(id);
   }
 
   @Post()
+  @Roles(Role.ADMIN)
   create(@Body() dto: CreateVersionDto): Promise<Version> {
     return this.service.create(dto);
   }
 
   @Put(':id')
+  @Roles(Role.ADMIN)
   update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateVersionDto): Promise<Version> {
     return this.service.update(id, dto);
   }
 
   @Delete(':id')
+  @Roles(Role.ADMIN)
   delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.service.delete(id);
   }


### PR DESCRIPTION
… and Versions controllers; ensure admin-only access for create, update, and delete operations.