### PR TITLE
feat(auth): include user details in login response

### DIFF
--- a/src/DTOs/usersDto/google-profile.dto.ts
+++ b/src/DTOs/usersDto/google-profile.dto.ts
@@ -1,13 +1,36 @@
-import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class GoogleProfileDto {
-  @IsString()
-  sub: string;
+  @IsEmail()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'Email del usuario de Google',
+    example: 'usuario@gmail.com'
+  })
+  email: string;
 
   @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'Nombre del usuario de Google',
+    example: 'Usuario Google'
+  })
   name: string;
 
   @IsString()
-  @IsEmail()
-  email: string;
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'ID único de Google (sub)',
+    example: '123456789'
+  })
+  sub: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    description: 'URL de la imagen de perfil',
+    example: 'https://lh3.googleusercontent.com/a/imagen.jpg'
+  })
+  image?: string;
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -82,7 +82,12 @@ export class AuthService {
     const jwtPayload = { sub: user.id, email: user.email };
     const token = this.jwtService.sign(jwtPayload);
 
-    return { success: 'Login successfully', token };
+    return { success: 'Login successfully', token, user: {
+		id: user.id,
+		name: user.name,
+		email: user.email,
+		role: user.role
+	} };
   }
 
   async createAdmin(user: Omit<CreateUserDto, 'confirmPassword'>) {


### PR DESCRIPTION
Add user details (id, name, email, role) to the login response to provide more context to the client. Also, enhance GoogleProfileDto with API property decorators and optional image field for better documentation and flexibility.