### PR TITLE
Refactor dotenv configuration to use default .env file in cloudinary …

### DIFF
--- a/src/config/cloudinary.config.ts
+++ b/src/config/cloudinary.config.ts
@@ -1,9 +1,7 @@
 import { v2 as cloudinary } from 'cloudinary';
 import { config as dotenvConfig } from 'dotenv';
 
-dotenvConfig({
-  path: '.env.development',
-});
+dotenvConfig();
 
 export const cloudinaryConfig = {
   provide: 'CLOUDINARY',

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -2,9 +2,7 @@ import { DataSource, DataSourceOptions } from 'typeorm';
 import { config as dotenvConfig } from 'dotenv';
 import { registerAs } from '@nestjs/config';
 
-dotenvConfig({
-  path: '.env.development',
-});
+dotenvConfig();
 
 const config = {
   type: 'postgres',


### PR DESCRIPTION
…and typeorm config