### PR TITLE
feat(acara-scraping): implement scraping module for vehicle data

### DIFF
--- a/marcas_modelos_versiones_acara.json
+++ b/marcas_modelos_versiones_acara.json
@@ -1,0 +1,8312 @@
+[
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 1,
+    "modelo": "147",
+    "versiones": [
+      "1.6 TS Progression (120cv) 3Ptas.",
+      "1.6 TS Progression (120cv) 5Ptas.",
+      "2.0 TS MT (150cv) 5Ptas.",
+      "2.0 TS Selespeed (150cv) 5Ptas.",
+      "1.9 JTD (150cv) 5Ptas.",
+      "1.9 JTD Cuero TC (150cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 2,
+    "modelo": "159",
+    "versiones": [
+      "1.8 TBi 6MT Cuero TC (200cv)",
+      "2.2 JTS 6MT Progression (185cv)",
+      "2.2 JTS Selespeed Cuero (185cv)",
+      "3.2 JTS 4x4 (260cv)",
+      "1.9 JTD Progression (150cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 3,
+    "modelo": "Brera",
+    "versiones": [
+      "2.2 JTS Selespeed Cuero (185cv)",
+      "3.2 V6 JTS 4x4 (260cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 4,
+    "modelo": "Giulia",
+    "versiones": [
+      "2.0T AT RDW Distinctive (200cv)",
+      "2.0T AT AWD Veloce (280cv)",
+      "2.9 Biturbo AT RWD Quadrifoglio (510cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 5,
+    "modelo": "Giulietta",
+    "versiones": [
+      "1.4Tbi 6MT Sprint (120hp)",
+      "1.4Tbi 6MT Progression (120hp)",
+      "1.4Tbi 6MT Distinctive (120hp)",
+      "1.4 Tbi MultiAir 6MT Progression (170hp)",
+      "1.4 Tbi MultiAir 6MT Distinctive (170hp)",
+      "1.4 Tbi MultiAir TCT Distinctive (170hp)",
+      "1.8Tbi 6MT Quadrifoglio Verde (230cv)",
+      "1.8Tbi Veloce TCT (240cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 6,
+    "modelo": "GT",
+    "versiones": [
+      "2.0 TC",
+      "2.0 TC Selespeed",
+      "3.2 V6 JTS (240cv)",
+      "1.9 JTD Distinctive (150cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 7,
+    "modelo": "Mito",
+    "versiones": [
+      "1.4 MT Progression (78cv)",
+      "1.4 6MT Junior (78cv)",
+      "1.4 Multiair 6MT Progression (105cv)",
+      "1.4 Multiair TCT Progression (105cv)",
+      "1.4 Multiair TCT Distinctive (135cv)",
+      "1.4 Multiair TCT Distinctive TC (135cv)",
+      "1.4 Tbi 5MT Sport (135cv)",
+      "1.4 Tbi 5MT Sport TC (135cv)",
+      "1.4 Tbi 6MT Distinctive (155cv)",
+      "1.4 Tbi 6MT Distinctive TC (155cv)",
+      "1.4T Veloce MT6 (170cv)",
+      "1.4T Veloce TCT (170cv)",
+      "1.4T 6MT Quadrifoglio Verde (170cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 8,
+    "modelo": "Spider",
+    "versiones": [
+      "2.2 JTS (185cv)",
+      "3.2 V6 JTS 4x4 (260cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 9,
+    "modelo": "Stelvio",
+    "versiones": [
+      "2.0T AT AWD Distinctive (200cv)",
+      "2.0T AT AWD Super-Veloce (280cv)",
+      "2.9 Biturbo AT RWD Quadrifoglio (510cv)"
+    ]
+  },
+  {
+    "marca": "ALFA ROMEO",
+    "modeloId": 690,
+    "modelo": "Tonale",
+    "versiones": [
+      "1.5T AT7 Sprint FWD MHEV (160cv-20cv)",
+      "1.5T AT7 Veloce FWD MHEV (160cv-20cv)",
+      "1.3T Tributo Italiano Q4 PHEV (275cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 10,
+    "modelo": "A1",
+    "versiones": [
+      "1.2 TFSi MT Attraction (86cv)",
+      "1.4 TFSi MT Attraction (122cv)",
+      "1.4 TFSi S-Tronic Attraction (122cv)",
+      "1.4 TFSi MT Ambition (122cv)",
+      "1.4 TFSi S-Tronic Ambition (122cv)",
+      "1.4 TFSi S-Tronic S-Line (185cv)",
+      "1.4 TFSi S-Tronic S-Line Pack Tecnology (185cv)",
+      "Sportback 30 TFSI (116cv)",
+      "Sportback 35 TFSI (150cv)",
+      "Sportback 40 TFSI S-Line (200cv)",
+      "Sportback 1.4 TFSi MT Ambition (122cv)",
+      "Sportback 1.4 TFSi S-Tronic Ambition (122cv)",
+      "Sportback 1.4 TFSi S-Tronic S-Line (185cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 11,
+    "modelo": "A3",
+    "versiones": [
+      "1.4 TFSI (150cv) MT 3Ptas.",
+      "1.4 TFSI (125cv) MT Cuero Premium 3Ptas.",
+      "1.4 TFSI (150cv) S-Tronic 3Ptas.",
+      "1.4 TFSI (125cv) S-Tronic Cuero Premium 3Ptas.",
+      "1.6 (102cv) 3Ptas.",
+      "1.6 (102cv) Cuero Premium 3Ptas.",
+      "1.8 TFSI MT 3Ptas. (180cv) (L13)",
+      "1.8 TFSI S-tronic 3Ptas. (180cv) (L13)",
+      "1.8 TFSI (160cv) S-tronic Quattro 3Ptas. (180cv) (L13)",
+      "1.8 TFSI MT (160cv) 3Ptas.",
+      "1.8 TFSI MT (160cv) Pack Premium 3Ptas.",
+      "1.8 TFSI (160cv) S-tronic 3Ptas.",
+      "1.8 TFSI (160cv) S-tronic Pack Premium",
+      "2.0 TFSI S-Tronic 3Ptas. (190cv) (L17)",
+      "2.0 TFSI (200cv) MT",
+      "2.0 TFSI (200cv) MT Cuero Premium",
+      "2.0 TFSI (200cv) Tiptronic",
+      "2.0 TFSI (200cv) Tiptronic Cuero Premium",
+      "2.0 TDI S-Tronic (143cv) (L13)",
+      "2.0 TDI MT (140cv)",
+      "2.0 TDI MT Cuero (140cv)",
+      "2.0 TDI S-Tronic / DSG (140cv)",
+      "2.0 TDI S-Tronic / DSG Cuero (140cv)",
+      "1.4 TFSI S-Tronic Serie (150cv) 4Ptas.",
+      "1.4 TFSI S-Tronic Advance (150cv) 4Ptas.",
+      "35 TFSI S-Tronic (150cv) 4Ptas.",
+      "40 TFSI S-tronic S-line Style (150cv) 4Ptas.",
+      "1.4 TFSI (150cv) MT 4Ptas.",
+      "1.4 TFSI (150cv) S-tronic 4Ptas.",
+      "1.8 TFSI (180cv) MT 4Ptas.",
+      "1.8 TFSI (180cv) S-tronic 4Ptas.",
+      "1.8 TFSI (180cv) S-tronic Quattro 4Ptas.",
+      "2.0 TFSI (190cv) S-tronic 4Ptas.",
+      "2.0 TFSI (190cv) S-tronic S-Line 4Ptas.",
+      "Sportback 1.4 TFSI S-Tronic Serie (150cv)",
+      "Sportback 1.4 TFSI S-Tronic Advance (150cv)",
+      "Sportback 35 TFSI S-Tronic (150cv)",
+      "Sportback 40 TFSI S-tronic S-line Style (190cv)",
+      "Sportback 1.4 TFSI MT (150cv)",
+      "Sportback 1.4 TFSI (125cv) MT Cuero Premium",
+      "Sportback 1.4 TFSI S-Tronic (150cv)",
+      "Sportback 1.4 TFSI (125cv) S-Tronic Cuero Premium",
+      "Sportback 1.6 (102cv) MT",
+      "Sportback 1.6 (102cv) MT Cuero Premium",
+      "Sportback 1.6 (102cv) Tiptronic",
+      "Sportback 1.6 (102cv) Tiptronic Cuero Premium",
+      "Sportback 1.8 TFSI (180cv) MT",
+      "Sportback 1.8 TFSI (180cv) S-tronic",
+      "Sportback 1.8 TFSI (180cv) S-tronic Quattro",
+      "Sportback 1.8 TFSI (160cv) MT",
+      "Sportback 1.8 TFSI (160cv) MT Cuero Premium",
+      "Sportback 1.8 TFSI (160cv) S-tronic",
+      "Sportback 1.8 TFSI (160cv) S-tronic Cuero Premium",
+      "Sportback 2.0 TFSI S-Tronic (190cv) (L17)",
+      "Sportback 2.0 TFSI S-Line S-tronic (190cv) 4Ptas.",
+      "Sportback 2.0 TFSI (200cv)",
+      "Sportback 2.0 TFSI Pack Premium (200cv)",
+      "Sportback 2.0 TFSI S-Tronic / Tiptronic (200cv)",
+      "Sportback 2.0 TFSI Tiptronic Pack Premium (200cv)",
+      "Sportback 2.0 TDI MT (140cv)",
+      "Sportback 2.0 TDI MT Premium (140cv)",
+      "Sportback 2.0 TDI S-Tronic / DSG (140cv)",
+      "Sportback 2.0 TDI DSG Premium (140cv)",
+      "Cabrio 1.8 TFSi MT (160cv)",
+      "Cabrio 1.8 TFSi S-Tronic (160cv)",
+      "S3 2.0 TFSI MT Quattro (255cv)",
+      "S3 2.0 TFSI S-Tronic Quattro (255cv)",
+      "S3 Sportback 2.0 TFSI MT Quattro (255cv)",
+      "S3 Sportback 2.0 TFSI S-Tronic Quattro (255cv)",
+      "S3 Sportback 2.0 TFSI S-Tronic Quattro (310cv)",
+      "S3 Sportback 2.0 TFSI S-Tronic Quattro (290cv)",
+      "S3 2.0 TFSI S-Tronic Quattro (290cv) 4Ptas.",
+      "S3 2.0 TFSI S-Tronic Quattro (310cv) 4Ptas.",
+      "RS3 2.5 TFSI Tiptronic Quattro (400cv) 4Ptas.",
+      "RS3 Sportback 2.5 TFSI Tiptronic Quattro (400cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 12,
+    "modelo": "A4",
+    "versiones": [
+      "1.8T FSI (170cv) MT Attraction",
+      "1.8T FSI (170cv) MT Ambition",
+      "1.8T FSI (170cv) Multitronic Attraction",
+      "1.8T FSI (170cv) Multitronic Ambition",
+      "1.8T FSI (160cv) MT Plus",
+      "1.8T FSI (160cv) MT Sport Cuero",
+      "1.8T FSI (160cv) MT Sport Cuero Plus",
+      "1.8T FSI (160cv) Multitronic Plus",
+      "1.8T FSI (160cv) Multitronic Sport Cuero",
+      "1.8T FSI (160cv) Multitronic Sport Cuero Plus",
+      "40 TFSI S-tronic (190cv) Mild-Hybrid",
+      "40 TFSI Advanced S-tronic (190cv) Mild-Hybrid",
+      "45 TFSI 2.0 Quattro S-Tronic (245cv) (L23)",
+      "2.0 TFSI MT (190cv) (L16)",
+      "2.0 TFSI S-Tronic (190cv) (L16)",
+      "2.0 TFSI S-Tronic Front (252cv)",
+      "2.0 TFSI MT (225cv) Attraction",
+      "2.0 TFSI MT (225cv) Ambition Plus",
+      "2.0 TFSI MT (211cv) Sport Cuero",
+      "2.0 TFSI Multitronic (225cv) Attraction",
+      "2.0 TFSI Multitronic (225cv) Ambition Plus",
+      "2.0 TFSI Multitronic (211cv) Sport Cuero",
+      "2.0 TFSI Quattro S-Tronic (252cv) (L16)",
+      "2.0 TFSI Quattro MT (211cv) Attraction",
+      "2.0 TFSI Quattro MT (211cv) Ambition Plus",
+      "2.0 TFSI Quattro MT (211cv) Sport Cuero",
+      "2.0 TFSI Quattro S-tronic (225cv) Attraction",
+      "2.0 TFSI Quattro S-tronic (225cv) Ambition Plus",
+      "2.0 TFSI Quattro S-tronic (211cv) Sport Cuero",
+      "3.0 TFSI S-Tronic Quattro (272cv)",
+      "3.2 FSI (265cv) MT Quattro (L08)",
+      "3.2 FSI (265cv) Tiptronic Quattro (L08)",
+      "2.0 TDI (143cv) MT (L08)",
+      "2.0 TDI (143cv) MT Plus (L08)",
+      "2.0 TDI (143cv) MT Sport Cuero (L08)",
+      "2.0 TDI (150cv) Multitronic Attraction (L08)",
+      "2.0 TDI (150cv) Multitronic Ambition Plus (L08)",
+      "2.0 TDI (143cv) Multitronic Sport Cuero (L08)",
+      "3.0 TDI (245cv) S-tronic Quattro (L08)",
+      "Avant 1.8 TFSI MT (160cv) Attraction (L09)",
+      "Avant 1.8 TFSI MT (160cv) Plus (L09)",
+      "Avant 1.8 TFSI MT (160cv) Ambition / Sport Cuero",
+      "Avant 1.8 TFSI Multitronic (160cv) Attraction (L09)",
+      "Avant 1.8 TFSI Multitronic (160cv) Plus (L09)",
+      "Avant 1.8 TFSI Multitronic (160cv) Ambition / Sport Cuero (L09)",
+      "Avant 3.2 FSI Tiptronic Quattro (265cv) (L09)",
+      "Avant 2.0 TDI (143cv) MT (L09)",
+      "Avant 2.0 TDI (143cv) MT Plus (L09)",
+      "Avant 2.0 TDI (143cv) MT Sport Cuero (L09)",
+      "Avant 2.0 TDI (143cv) Multitronic Attraction (L09)",
+      "Avant 2.0 TDI (143cv) Multitronic Plus (L09)",
+      "Avant 2.0 TDI (143cv) Multitronic Ambition / Sport Cuero (L09)",
+      "Avant 3.0 TDI Quattro Tiptronic (240cv)",
+      "Allroad 45 TFSI 2.0 Quattro S-Tronic (245cv) (L23)",
+      "Allroad 2.0 TFSI Quattro MT (211cv) (L09)",
+      "AllRoad 2.0 TFSI Quattro S-Tronic (252cv) (L18)",
+      "Allroad 2.0 TFSI Quattro S-Tronic Attraction (225cv)",
+      "Allroad 2.0 TFSI Quattro S-Tronic Ambition / Luxury (L13)",
+      "S4 3.0 V6 Quattro Tiptronc (354cv) (L17)",
+      "S4 3.0 V6 Quattro MT (333cv) (L09)",
+      "S4 3.0 V6 Quattro S-Tronic (333cv) (L09)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 13,
+    "modelo": "A5",
+    "versiones": [
+      "40 TFSI Sportback S-Tronic (190cv)",
+      "45 TFSI Sportback 2.0 S-Tronic Quattro (245cv)",
+      "40 TFSI Coupé 2.0 S-Tronic (190cv)",
+      "45 TFSI Coupé 2.0 S-Tronic Quattro (245cv)",
+      "Sportback 40 TFSI Front",
+      "Sportback 45 TFSI Quattro",
+      "Sportback 2.0 TFSI MT (225cv)",
+      "Sportback 2.0 TFSI MT (211cv) Sport Cuero",
+      "Sportback 2.0 TFSI MT (211cv) Plus",
+      "Sportback 2.0 TFSI S-Tronic (190cv) (L17)",
+      "Sportback 2.0 TFSI Multitronic (225cv)",
+      "Sportback 2.0 TFSI Multitronic (211cv) Sport Cuero",
+      "Sportback 2.0 TFSI Multitronic (211cv) Plus",
+      "Sportback 2.0 TFSI Quattro MT (211cv)",
+      "Sportback 2.0 TFSI Quattro MT (211cv) Sport Cuero",
+      "Sportback 2.0 TFSI S-Tronic Quattro (252cv) (L17)",
+      "Sportback 2.0 TFSI Quattro S-Tronic (225cv)",
+      "Sportback 2.0 TFSI Quattro S-Tronic (211cv) Sport Cuero",
+      "Sportback 2.0 TFSI Quattro S-Tronic (211cv) Sport Cuero (L12)",
+      "Sportback 3.0 FSI Quattro S-Tronic (272cv)",
+      "Sportback 3.2 FSI S-Tronic Quattro (265cv)",
+      "Sportback S5 3.0 TFSI S-Tronic Quattro (354cv)",
+      "Coupé 40 TFSI Front",
+      "Coupé 45 TFSI Quattro",
+      "Coupé 2.0 TFSI (225cv) MT",
+      "Coupé 2.0 TFSI (211cv) MT Sport Cuero",
+      "Coupe  2.0 TFSI S-Tronic (190cv) (L17)",
+      "Coupé 2.0 TFSI (225cv) Multitronic",
+      "Coupé 2.0 TFSI (211cv) Multitronic Sport Cuero",
+      "Coupé 2.0 TFSI (211cv) MT Quattro",
+      "Coupé 2.0 TFSI (211cv) MT Quattro Sport Cuero",
+      "Coupe 2.0 TFSI S-Tronic Quattro (252cv) (L17)",
+      "Coupé 2.0 TFSI (225cv) S-tronic Quattro",
+      "Coupé 2.0 TFSI (211cv) S-tronic Quattro Sport Cuero",
+      "Coupé 3.0 FSI S-tronic Quattro (272cv)",
+      "Coupé 3.2 FSI MT Quattro (265cv)",
+      "Coupé 3.2 FSI Tiptronic Quattro (265cv)",
+      "Coupe S5 3.0 TFSI S-Tronic Quattro (354cv) (L17)",
+      "S5 4.2 MT Quattro (354cv)",
+      "S5 3.0 S-Tronic Quattro (333cv)",
+      "S5 4.2 Tiptronic Quattro (354cv)",
+      "RS5 2.9T FSI S-tronic Quattro (450cv) Coupé",
+      "RS5 4.2 FSI S-tronic Quattro (450cv) Coupé",
+      "Cabrio 3.0 FSI S-tronic Quattro (272cv)",
+      "Cabrio 3.2 FSI S-tronic Quattro (265cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 14,
+    "modelo": "A6",
+    "versiones": [
+      "55 TFSI S-tronic Quattro (340cv) Mild-Hybrid",
+      "2.8 FSI Multitronic (204cv) (L10)",
+      "3.0T FSI S-Tronic Quattro (333cv)",
+      "4.2 FSI Tiptronic Quattro",
+      "4.2 FSI Security Tiptronic Quattro (350cv)",
+      "3.0 TDI Tiptronic Quattro (240cv)",
+      "Allroad 55 TFSI S-tronic Quattro (340cv) Mild-Hybrid",
+      "Allroad 3.0T FSI S-Tronic Quattro (310cv)",
+      "Allroad 4.2 FSI Tiptronic Quattro (350cv)",
+      "Allroad 3.0 TDI S-Tronic Quattro (245cv)",
+      "RS6 5.0T FSI Tiptronic Quattro (580cv)",
+      "S6 4.0T FSI S-Tronic Quattro (420cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 15,
+    "modelo": "A7",
+    "versiones": [
+      "Sportback 55 TFSI S-tronic Quattro (340cv) Mild-Hybrid",
+      "Sportback 3.0T FSI V6 S-Tronic Quattro",
+      "Sportback 3.0 TDI V6 S-Tronic Quattro (245cv)",
+      "S7 Sportback 4.0 V8 S-tronic Quattro (420cv)",
+      "RS7 4.0 V8 AT (560cv) Quattro Sportback"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 16,
+    "modelo": "A8",
+    "versiones": [
+      "L 60 TFSI Tiptronic Quattro (460cv) Mild-Hybrid",
+      "4.0 TFSI V8 Tiptronic Quattro (420cv)",
+      "4.2 FSI Tiptronic Quattro (372cv)",
+      "4.2 FSI Tiptronic Quattro (350cv)",
+      "L 4.0 TFSI Tiptronic Quattro (420cv)",
+      "L 4.2 FSI Tiptronic Quattro (372cv)",
+      "L 4.2 FSI Tiptronic Quattro (350cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 17,
+    "modelo": "e-tron",
+    "versiones": [
+      "55 Quattro (300kw) (408cv)",
+      "Sportback 55 Quattro (300kw) (408cv)",
+      "RS GT (300kw) (646cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 18,
+    "modelo": "Q2",
+    "versiones": [
+      "30 TFSI  S-tronic Sport (116cv)",
+      "35 TFSI S-tronic Serie (150cv)",
+      "35 TFSI S-tronic Advanced (150cv)",
+      "35 TFSI S-tronic Sport (150cv)",
+      "40 TFSI S-tronic Quattro (190cv)",
+      "1.4 TFSI S-tronic Serie",
+      "1.4 TFSI S-tronic Sport",
+      "1.4 TFSI S-tronic Off Road Style",
+      "2.0 TFSI S-tronic Sport Quattro"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 19,
+    "modelo": "Q3",
+    "versiones": [
+      "35 TFSI (150cv)",
+      "40 TFSI Quattro Advance (180cv)",
+      "1.4 TFSI MT (150cv)",
+      "1.4 TFSI S-Tronic (150cv)",
+      "2.0 TFSI MT Quattro (170cv)",
+      "2.0 TFSI S-tronic Quattro (170cv)",
+      "2.0 TFSI S-tronic Quattro (211cv)",
+      "2.0 TDI S-tronic Quattro (177cv)",
+      "Sportback 35 TFSI (150cv)",
+      "Sportback 40 TFSI Quattro (180cv)",
+      "Sportback 40 TFSI Quattro S-Line (180cv)",
+      "RS Sportback 2.5T S-Tronic Quattro (180cv) DISCONTINUO"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 20,
+    "modelo": "Q5",
+    "versiones": [
+      "45 TFSI Offroad S-tronic Quattro (245cv)",
+      "45 TFSI Advance Sport S-tronic Quattro (245cv)",
+      "Sportback 45 TFSI Advanced S-tronic Quattro (245cv)",
+      "Sportback 45 TFSI S-line S-tronic Quattro (245cv)",
+      "Security 45 TFSI S-tronic Quattro (252cv)",
+      "SQ5 55 TFSI Tiptronic Quattro (354cv)",
+      "2.0 TFSI S-Tronic Quattro (252cv) (L17)",
+      "2.0 TFSI S-Tronic Quattro Security (252cv) (L17)",
+      "SQ5 3.0 TFSI Tiptronic Quattro (354cv) (L17)",
+      "2.0 TFSI MT Quattro (180cv)",
+      "2.0 TFSI MT Quattro (225cv)",
+      "2.0 TFSI MT Quattro (211cv)",
+      "2.0 TFSi S-Tronic Quattro (211cv)",
+      "2.0 TFSI Tiptronic Quattro (225cv)",
+      "3.0 TFSI Tiptronic Quattro (272cv)",
+      "3.2 FSI S-Tronic Quattro (271cv)",
+      "2.0 TDI S-Tronic Quattro (177cv)",
+      "2.0 TDI MT Quattro (170cv)",
+      "3.0 TDI S-Tronic Quattro (245cv)",
+      "3.0 TDI S-Tronic Quattro (239cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 22,
+    "modelo": "Q7",
+    "versiones": [
+      "45 TDI S-Line Quattro (249cv)",
+      "55 TFSI Offroad Quattro (340cv) Mild-Hybrid",
+      "55 TFSI S-Line Quattro (340cv) Mild-Hybrid",
+      "3.0 TDI Tiptronic Quattro (249cv)",
+      "3.0 TDI Tiptronic Quattro Security (233cv)",
+      "4.2 TDI Tiptronic Quattro (340cv)",
+      "4.2 TDI Tiptronic Quattro Security (326cv)",
+      "3.0T FSI Tiptronic Quattro (272cv)",
+      "3.0T FSI Tiptronic Quattro Security (272cv)",
+      "3.0T FSI Tiptronic Quattro Sport (272cv)",
+      "3.0T FSI Tiptronic Quattro (333cv)",
+      "3.0T FSI Tiptronic Quattro Security (333cv)",
+      "3.0T FSI Tiptronic Quattro Sport (333cv)",
+      "4.2 FSI Tiptronic Quattro Luxury (350cv)",
+      "4.2 FSI Tiptronic Quattro Sport (350cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 21,
+    "modelo": "Q8",
+    "versiones": [
+      "Sportback 55 e-tron Quattro (300kw) (408cv)",
+      "55 TFSI Tiptronic Quattro (340cv)",
+      "45 TDI Tiptronic Quattro (249cv)",
+      "RS Performance Quattro (640cv)",
+      "RS Quattro (600cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 23,
+    "modelo": "R8",
+    "versiones": [
+      "Coupé 5.2 FSI Plus S-Tronic Quattro (610cv)",
+      "Spyder 5.2 FSI Plus S-Tronic Quattro (610cv)",
+      "4.2 FSI MT Quattro (420cv)",
+      "4.2 FSI S-Tronic Quattro (420cv)",
+      "5.2 FSI MT Quattro (525cv)",
+      "5.2 FSI S-tronic Quattro (525cv)",
+      "Spyder 5.2 FSI MT Quattro (525cv)",
+      "Spyder 5.2 FSI S-tronic Quattro (525cv)"
+    ]
+  },
+  {
+    "marca": "AUDI",
+    "modeloId": 24,
+    "modelo": "TT",
+    "versiones": [
+      "Coupé 2.0 TFSi S-Tronic (230cv) (L17)",
+      "TTS Coupé 2.0 TFSi S-Tronic Quattro (310cv) (L17)",
+      "TTS Roadster 2.0 TFSi S-Tronic Quattro (310cv) (L17)",
+      "RS Coupé 2.5 TFSi S-Tronic Quattro (400cv) (L17)",
+      "Coupé 1.8T FSI MT (160cv)",
+      "Coupé 1.8T FSI MT Premium / Sport (160cv)",
+      "Coupé 2.0 TFSI MT (211cv)",
+      "Coupé 2.0 TFSI MT Sport / Premium (211cv)",
+      "Coupé 2.0 TFSI S-Tronic (211cv)",
+      "Coupé 2.0 TFSI S-Tronic Sport / Premium (211cv)",
+      "Coupé RS 2.5T FSI MT Quattro (340cv)",
+      "Coupé RS 2.5T FSI S-Tronic Quattro (340cv)",
+      "Coupé 3.2 V6 MT Quattro (250cv)",
+      "Coupé 3.2 V6 MT Sport Quattro (250cv)",
+      "Coupé 3.2 V6 S-Tronic / DSG Quattro (250cv)",
+      "Coupé 3.2 V6 S-Tronic Sport Quattro (250cv)",
+      "Roadster 1.8 TFSI MT (160cv)",
+      "Roadster 2.0 TFSI MT (211cv)",
+      "Roadster 2.0 TFSI S-Tronic (211cv)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 1486,
+    "modelo": "BJ30",
+    "versiones": [
+      "1.5T AT 2WD Hybrid (156-174/330cv)",
+      "1.5T AT 4WD Hybrid (156-174/330cv)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 25,
+    "modelo": "BJ40",
+    "versiones": [
+      "2.0TD AT8 4x4 (220cv)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 971,
+    "modelo": "BJ60",
+    "versiones": [
+      "2.0T AT8 4x4 MH (263cv)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 26,
+    "modelo": "D20",
+    "versiones": [
+      "1.3 MT (113cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 970,
+    "modelo": "U5",
+    "versiones": [
+      "1.5 CVT (115cv)",
+      "EU5 EV 120kw (161cv)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 27,
+    "modelo": "X25",
+    "versiones": [
+      "1.5 MT (114hp)",
+      "1.5 AT (114hp)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 28,
+    "modelo": "X35",
+    "versiones": [
+      "1.5 AT Fashion (114hp) (L21)",
+      "1.5 AT Luxury (114hp) (L21)",
+      "1.5 MT (114hp)",
+      "1.5 AT (114hp)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 29,
+    "modelo": "X55",
+    "versiones": [
+      "II 1.5T CVT (185hp)",
+      "II 1.5T CVT Plus (185hp)",
+      "1.5T CVT (148hp)"
+    ]
+  },
+  {
+    "marca": "BAIC",
+    "modeloId": 30,
+    "modelo": "X65",
+    "versiones": [
+      "2.0 6AT Luxury (176cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 778,
+    "modelo": "Adventure",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 777,
+    "modelo": "Heritage",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 779,
+    "modelo": "R Nine T",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 31,
+    "modelo": "Serie 1",
+    "versiones": [
+      "118i Advantage AT (156cv) (L25) 5Ptas.",
+      "118i SportLine AT (156cv) (L25) 5Ptas.",
+      "118i Advantage (140cv) (L20) 5Ptas.",
+      "118i SportLine (140cv) (L20) 5Ptas.",
+      "120i Active (177cv) (L16) 3Ptas.",
+      "118i Active (136cv) 5Ptas. (L16)",
+      "118i Sport (136cv) 5Ptas.(L16)",
+      "120i Active (177cv) 5Ptas. (L16)",
+      "120i Sport (184cv) 5Ptas. (L16)",
+      "120i Sport Line (177cv) 5Ptas. (L16)",
+      "120i M Package (177cv) 5Ptas. (L16)",
+      "125i SportLine (218cv) 3Ptas. (L12)",
+      "135i M Performance (320cv) 3Ptas. (L12)",
+      "118i Sport (170cv) 5Ptas. (L12)",
+      "118d Sport (143cv) 5Ptas. (L12)",
+      "120d Urban (184cv) 5Ptas. (L12)",
+      "120d Sport (184cv) 5Ptas. (L12)",
+      "125d (218cv) 5Ptas. (L12)",
+      "116i Active (115cv) 3Ptas. (L10)",
+      "118i Active (136cv) 3Ptas. (L10)",
+      "130i Limited (258cv) 3Ptas. (L10)",
+      "116i Active (115cv) 5Ptas. (L06)",
+      "118i Active (136cv) 5Ptas. (L10)",
+      "120i Active (156cv) 5Ptas. (L06)",
+      "120d Active (177cv) 5Ptas. (L06)",
+      "130i M Sport Package (258cv) 5Ptas. (L06)",
+      "120i Executive Coupé (156cv) (L10)",
+      "125i Active Coupé (L06)",
+      "125i Sportive Coupé (L06)",
+      "125i Executive Coupé (218cv) (L06)",
+      "135i Sportive Coupé (306cv) (L06)",
+      "120i Active Cabrio (156cv) (L06)",
+      "M135 xDrive M Performence (317cv) (L25) 5Ptas.",
+      "M135 xDrive M Performence (306cv) 5Ptas.",
+      "M140i 3.0 AT8 (340cv) Coupé",
+      "M140i 3.0 AT8 (340cv) 5Ptas.",
+      "M1 Coupé (340cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 32,
+    "modelo": "Serie 2",
+    "versiones": [
+      "218i Gran Coupé Advantage (140cv) 4Ptas.",
+      "220i Coupé Advantage (184cv)",
+      "220i Coupé LCI SportLine (184cv)",
+      "220i Coupé LCI Sport (184cv)",
+      "220i Coupé LCI II MSport (184cv)",
+      "220i Coupé Sport (184cv)",
+      "220i Cabrio LCI Sport (184cv)",
+      "220i Cabrio Sport (184cv)",
+      "M235i Coupé Package M (326cv)",
+      "M235i xDrive Gran Coupé MPerformance (306cv) 4Ptas.",
+      "M240i xDrive Coupé MPerformance (388cv)",
+      "M240i Coupé LCI Sport (340cv)",
+      "M240i Coupé Package M (340cv)",
+      "M240i Coupé LCI II MPerformance (340cv)",
+      "M240i Cabrio Package M (340cv)",
+      "M2 Coupé (370cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 33,
+    "modelo": "Serie 3",
+    "versiones": [
+      "320i Sedán Executive / Premium (156cv) (L09)",
+      "320i Sedán Executive (184cv)",
+      "320i Sedán SportLine (184cv)",
+      "320i Coupé Executive (L09)",
+      "320d Sedán Executive (184cv) (L09)",
+      "320d Sport/Luxury Sedán (184cv) (L12)",
+      "320d Touring Active",
+      "325i Sedán Executive (L09)",
+      "325i Sedán X Drive",
+      "325i Coupé Executive",
+      "325i Cabrio Pack M (L09)",
+      "328i Sedán Sport/Luxury (245cv) (L12)",
+      "328i Gran turismo Luxury (245cv) Sedán (L12)",
+      "330i Sedán Sport Line Shadow (252cv)",
+      "330i Sedán Sport Line (252cv)",
+      "330i Sedán Executive (258cv) (L09)",
+      "330i Sedán MSport (258cv)",
+      "330i Cabrio Executive (258cv)",
+      "330d Sedán Executive",
+      "330e Sedán SportLine (184/108e-292cv)",
+      "335i Sedán (L09)",
+      "335i Sedán X Drive (L09)",
+      "335i Sedán Package M Sport Biturbo (306cv) (L12)",
+      "335i Coupé Package M Sport Biturbo (306cv) (L12)",
+      "M340i xDrive MPerformance Sedán (387cv)",
+      "M3 4.0 V8 MT Sport Coupé (420cv)",
+      "M3 4.0 V8 Black & White Edition (420cv)",
+      "M3 3.0BT Competition AT8 (510cv) Sedan",
+      "M3 Sedán (431cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 34,
+    "modelo": "Serie 4",
+    "versiones": [
+      "430i Coupé M Sport Package (258cv)",
+      "M440i Coupé xDrive M Performance (387cv)",
+      "428i Coupé Sport Line (245cv)",
+      "430i Coupé Sport Line (252cv)",
+      "435i Coupé M Package (306cv)",
+      "440i Coupé M Package (326cv)",
+      "430i Gran Coupé Sport (252cv)",
+      "435i Gran Coupé M Package (306cv)",
+      "440i Gran Coupé M Package (326cv)",
+      "440i Cabrio (326cv)",
+      "M4 Competition Coupé (510cv) (L23) DISCONTINUO",
+      "M4 Coupé (431cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 35,
+    "modelo": "Serie 5",
+    "versiones": [
+      "550e xDrive (331/197-490cv)",
+      "525d Executive (218cv)",
+      "525d Executive (204cv)",
+      "528i Executive (258cv)",
+      "530i Package M (252cv)",
+      "530i Package M (252cv) (L17)",
+      "530i Executive (258cv)",
+      "530i Executive",
+      "530d Executive (245cv)",
+      "530d Executive (218cv)",
+      "535i Package M (306cv)",
+      "535i Executive (306cv)",
+      "540i Package M (340cv) (L17)",
+      "550i Premium (407cv)",
+      "550i Premium",
+      "535i Gran Turismo Executive (306cv)",
+      "M5",
+      "M5 Premium (507cv)",
+      "M5 Sedan 35 Jahre (625cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 36,
+    "modelo": "Serie 6",
+    "versiones": [
+      "640i Sportive Coupé (L12) (320cv)",
+      "640i Sportive Cabrio (L12) (320cv)",
+      "650i Coupé Package M (449cv)",
+      "650i Grand Coupé Package M (449cv)",
+      "650Ci Coupé Premium",
+      "M6 Grand Coupé (560cv)",
+      "M6 (507cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 37,
+    "modelo": "Serie 7",
+    "versiones": [
+      "750Li xDrive MSport Pure Exc. (530cv)",
+      "750i Premium Pack M (449cv)",
+      "750i Premium (407cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 38,
+    "modelo": "Serie 8",
+    "versiones": [
+      "M850I xDrive Coupé (530cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 782,
+    "modelo": "Sport",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 780,
+    "modelo": "Tour",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 781,
+    "modelo": "Urban",
+    "versiones": null
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 39,
+    "modelo": "X1",
+    "versiones": [
+      "18i sDrive Advantage (140cv)",
+      "18i sDrive Active (140cv)",
+      "20i sDrive Active (184cv)",
+      "20i sDrive SportLine (192cv)",
+      "20i sDrive SportLine (192cv)",
+      "20i xDrive xLine (204cv)",
+      "20i xDrive Excecutive (184cv)",
+      "25i xDrive xLine (231cv)",
+      "28i xDrive Executive (265cv)",
+      "20d sDrive Active MT 4x2 (177cv)",
+      "20d xDrive Active MT 4x4 (177cv)",
+      "20d xDrive Active AT 4x4 (177cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 40,
+    "modelo": "X2",
+    "versiones": [
+      "2.0 xDrive20i M Sport AT8 AWD (204cv) (L24)",
+      "iX2 xDrive30 M Sport AWD (e313cv) (L24)",
+      "sDrive20i MSportX (192cv)",
+      "M35i MPerformance (306cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 41,
+    "modelo": "X3",
+    "versiones": [
+      "2.5si Selective",
+      "sDrive 20i (184cv)",
+      "xDrive 20i (184cv)",
+      "xDrive20i LCI xLine (184cv)",
+      "xDrive20i xLine Steptronic MildHybrid (208cv) (L25)",
+      "xDrive 25i Limited Edition (218cv)",
+      "xDrive 28i xLine (245cv)",
+      "xDrive 30i xLine Sport (192cv)",
+      "xDrive 30i xLine S-Line (184cv)",
+      "xDrive 30i Advantage (252cv)",
+      "xDrive 30i xLine (252cv)",
+      "xDrive30i LCI xLine (252cv)",
+      "xDrive 30i MSport (252cv)",
+      "xDrive30e LCI xLine (292cv)",
+      "xDrive 35i Sportive (306cv)",
+      "xDrive 35i M Package (306cv)",
+      "xDrive 20d Executive (184cv)",
+      "M40I Performance M (360cv)",
+      "M50 xDrive M Performance Steptronic MildHybrid (398cv) (L25)",
+      "M (480cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 42,
+    "modelo": "X4",
+    "versiones": [
+      "xDrive 3.0i xLine (252cv)",
+      "xDrive M40i (354hp)",
+      "M40i MPerformance (388cv)",
+      "20i xDrive Active (184cv)",
+      "28i xDrive xLine (245cv)",
+      "35i xDrive M Package (306cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 43,
+    "modelo": "X5",
+    "versiones": [
+      "xDrive40i LCI M Sport Pro MHEV (381cv)",
+      "3.0 Executive",
+      "35i xDrive Pure Excellence (306cv)",
+      "35i xDrive Executive (306cv)",
+      "3.0d Executive",
+      "40i xDrive xLine (340cv)",
+      "40d xDrive M Sport / Pure Excellence (313cv)",
+      "30d xDrive Executive (245cv)",
+      "4.8is/A Premium",
+      "50i xDrive M Sport (449cv)",
+      "50i xDrive Premium (407cv)",
+      "50i xDrive Premium Security (407cv)",
+      "M (575cv) (L17)",
+      "M (555cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 44,
+    "modelo": "X6",
+    "versiones": [
+      "30d xDrive Executive (245cv)",
+      "35i xDrive Pure Extravagance (306cv)",
+      "35i xDrive 3.0 Sportive (306cv)",
+      "40i xDrive MSport (340cv)",
+      "50i xDrive M Package (449cv)",
+      "50i xDrive 4.4 Premium (407cv)",
+      "xDrive40i LCI MSportPro (375cv)",
+      "M Competition MildHybrid (626cv)",
+      "M (600cv)",
+      "M (575cv) (L17)",
+      "M (555cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 45,
+    "modelo": "X7",
+    "versiones": [
+      "50i MPerformance (530cv)",
+      "M60i xDrive MildHybrid (530cv)"
+    ]
+  },
+  {
+    "marca": "BMW",
+    "modeloId": 46,
+    "modelo": "Z4",
+    "versiones": [
+      "3.0si Coupé",
+      "3.0i Executive Roadster (258cv)",
+      "sDrive 20i Executive Roadster (184cv)",
+      "sDrive 23i Active Roadster (204cv)",
+      "sDrive 28i Executive Roadster (245cv)",
+      "sDrive 30i MSport (258cv)",
+      "sDrive 35i M Package (306cv)",
+      "sDrive 35is M Package (340cv)"
+    ]
+  },
+  {
+    "marca": "CHANGAN",
+    "modeloId": 47,
+    "modelo": "CS15",
+    "versiones": [
+      "1.5 Comfort MT (107cv)",
+      "1.5 Comfort AT (107cv)",
+      "1.5 Luxury AT (107cv)"
+    ]
+  },
+  {
+    "marca": "CHANGAN",
+    "modeloId": 48,
+    "modelo": "CS75",
+    "versiones": [
+      "1.8T Elite 6AT 2WD (177cv)"
+    ]
+  },
+  {
+    "marca": "CHANGAN",
+    "modeloId": 49,
+    "modelo": "Utilitarios",
+    "versiones": [
+      "M 201 - 1.2 Cargo Van (92cv)",
+      "MD 201 - 1.2 Pick-up (92cv)",
+      "MD 201 - 1.2 Cargo Box (92cv)",
+      "MD 201 - 1.2 Cargo Box Refrigerado"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 50,
+    "modelo": "Arrizo 5",
+    "versiones": [
+      "1.5 Comfort MT (115cv) 4Ptas.",
+      "1.5 Luxury MT (115cv) 4Ptas.",
+      "1.5 Luxury CVT (115cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 51,
+    "modelo": "Face",
+    "versiones": [
+      "1.3 N Luxury 16v (83cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 52,
+    "modelo": "Fulwin",
+    "versiones": [
+      "1.5 16v MT (107hp) 4Ptas.",
+      "1.5 16v MT (107hp) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 53,
+    "modelo": "Fulwin 2",
+    "versiones": [
+      "1.5 16v MT (107hp) 4Ptas.",
+      "1.5 16v MT (107hp) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 54,
+    "modelo": "QQ",
+    "versiones": [
+      "1.1 N Basic (68cv) 5Ptas.",
+      "1.1 N Light (68cv) 5Ptas.",
+      "1.1 N Comfort (68cv) 5Ptas.",
+      "1.1 N Light Security (68cv) 5Ptas.",
+      "1.1 N Comfort Security (68cv) 5Ptas.",
+      "1.0 N Light Security (68cv) 5Ptas. (L16)",
+      "1.0 N Comfort Security (68cv) 5Ptas. (L16)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 55,
+    "modelo": "Skin",
+    "versiones": [
+      "1.6 16v (119cv) 4Ptas.",
+      "1.6 16v (119cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 56,
+    "modelo": "Tiggo",
+    "versiones": [
+      "1.6 16v 4x2 Comfort (125cv)",
+      "2.0 16v 4x2 Comfort (138cv)",
+      "2.0 16v 4x2 Luxury AT (138cv)",
+      "2.0 16v 4x4 Luxury (138cv)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 57,
+    "modelo": "Tiggo 2",
+    "versiones": [
+      "1.5 Comfort MT (105cv)",
+      "1.5 Comfort AT (105cv)",
+      "1.5 Luxury MT (105cv)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 58,
+    "modelo": "Tiggo 2 PRO",
+    "versiones": [
+      "1.5 Comfort MT (105cv)",
+      "1.5 Comfort CVT (105cv)",
+      "1.5 Luxury MT (105cv)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 59,
+    "modelo": "Tiggo 3",
+    "versiones": [
+      "1.6 Comfort MT 4x2 (125cv) (L17)",
+      "1.6 Comfort 4x2 (125cv)",
+      "1.6 Luxury MT 4x2 (125cv) (L17)",
+      "1.6 Luxury CVT 4x2 (125cv) (L17)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 60,
+    "modelo": "Tiggo 4",
+    "versiones": [
+      "2.0 Comfort MT (122cv)",
+      "2.0 Comfort CVT (122cv)",
+      "PRO 1.5 Comfort MT (115cv)",
+      "PRO 1.5 Comfort CVT (115cv)",
+      "PRO 1.5T Luxury MT (147cv)",
+      "PRO 1.5T Luxury CVT (147cv)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 61,
+    "modelo": "Tiggo 5",
+    "versiones": [
+      "2.0 Comfort MT (138hp) (L18)",
+      "2.0 Comfort CVT (138hp) (L18)",
+      "2.0 Luxury MT (138hp) (L18)",
+      "2.0 Luxury Extra CVT (138hp) (L18)",
+      "2.0 Comfort MT (138hp)",
+      "2.0 Comfort CVT (138hp)",
+      "2.0 Luxury MT (138hp)",
+      "2.0 Luxury CVT (138hp)"
+    ]
+  },
+  {
+    "marca": "CHERY",
+    "modeloId": 62,
+    "modelo": "Tiggo 8 PRO",
+    "versiones": [
+      "1.5T Luxury CVT ADAS"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 63,
+    "modelo": "Agile",
+    "versiones": [
+      "1.4 LS / LS Spirit 5Ptas.",
+      "1.4 LT / LT Spirit 5Ptas.",
+      "1.4 LTZ / LTZ Spirit 5Ptas.",
+      "1.4 LTZ Google WiFi 5Ptas.",
+      "1.4 Effect 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 64,
+    "modelo": "Astra II",
+    "versiones": [
+      "GL 2.0 N 8v 4Ptas.",
+      "GLS 2.0 N 8v 4Ptas.",
+      "GL 2.0 N 8v 5Ptas.",
+      "GLS 2.0 N 8v 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 65,
+    "modelo": "Aveo",
+    "versiones": [
+      "LS 1.6 MT 4Ptas. (103cv)",
+      "LT 1.6 MT 4Ptas. (103cv)",
+      "LT 1.6 AT 4Ptas. (103cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 66,
+    "modelo": "Blazer",
+    "versiones": [
+      "2.8 TD DLX 4x2",
+      "2.8 TD DLX 4x4"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 67,
+    "modelo": "Camaro",
+    "versiones": [
+      "SS V8 6.2 8AT (461cv) (L17)",
+      "SS V8 6.2 8AT Convertible (461cv) (L17)",
+      "SS V8 6.2 6AT (405cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 68,
+    "modelo": "Captiva",
+    "versiones": [
+      "2.4 N LS MT 4X2 (167cv) (L17)",
+      "2.4 N LT MT 4X4 (167cv) (L17)",
+      "2.4 N LT MT 4X4 (136cv) (L09)",
+      "2.2 D LT MT 4X4 (184cv) (L12)",
+      "2.0 TDI LT MT 4X4 (150cv) (L09)",
+      "2.2 D LTZ AT 4X4 (184cv) (L17)",
+      "2.0 TDI LTZ AT 4X4 (150cv) (L09)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 69,
+    "modelo": "Celta",
+    "versiones": [
+      "1.4 N 8v LS (92cv) 3Ptas.",
+      "1.4 N 8v LS AA DA (92cv) 3Ptas. (L13)",
+      "1.4 N 8v LT Spirit (92cv) 3Ptas.",
+      "1.4 N 8v Advantage AA DA (92cv) 5Ptas. (L13)",
+      "1.4 N 8v LS Spirit (92cv) 5Ptas.",
+      "1.4 N 8v Advantage Pack (92cv) 5Ptas. (L13)",
+      "1.4 N 8v LT Spirit (92cv) 5Ptas.",
+      "1.4 N 8v LT Pack (92cv) 5Ptas. (L13)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 70,
+    "modelo": "Classic",
+    "versiones": [
+      "3Ptas. 1.4 N Cargo",
+      "3Ptas. 1.4 N Life / City",
+      "3Ptas. 1.4 N LS Pack AA DA",
+      "3Ptas. 1.4 N LT",
+      "4Ptas. 1.4 N LS Base",
+      "4Ptas. 1.4 N Spirit / LS AA DA",
+      "4Ptas. 1.4 N LS ABS ABC",
+      "4Ptas. 1.4 N LS Pack",
+      "4Ptas. 1.4 N LT Spirit",
+      "4Ptas. 1.4 N LT Spirit Pack",
+      "Wagon 1.4 N Life",
+      "Wagon 1.4 N LS Pack AA DA",
+      "Wagon 1.4 N LT"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 71,
+    "modelo": "Cobalt",
+    "versiones": [
+      "1.8 8v. LT MT (105cv)",
+      "1.8 8v. LT MT Advantage (105cv)",
+      "1.8 8v. LTZ MT (105cv)",
+      "1.8 8v. LTZ MT Advantage (105cv)",
+      "1.8 8v. LTZ AT (105cv)",
+      "1.8 8v. LTZ AT Advantage (105cv)",
+      "1.3D LT MT (75cv)",
+      "1.3D LTZ MT (75cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 72,
+    "modelo": "Corsa Classic",
+    "versiones": [
+      "3Ptas. 1.4/1.6 N Cargo",
+      "3Ptas. 1.4/1.6 N Life/Base (L09)",
+      "3Ptas. 1.4/1.6 N GL",
+      "3Ptas. 1.4/1.6 N GLS",
+      "4Ptas. 1.4/1.6 N Base",
+      "4Ptas. 1.4/1.6 N GL / Super",
+      "4Ptas. 1.4/1.6 N GLS/Full",
+      "Wagon 1.4/1.6 N GL",
+      "Wagon 1.4/1.6 N GLS"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 73,
+    "modelo": "Corsa II",
+    "versiones": [
+      "4Ptas. 1.8 Nafta GL Pack AA DA",
+      "4Ptas. 1.8 Nafta CD",
+      "4Ptas. 1.8 Nafta Easytronic",
+      "5Ptas. 1.8 Nafta GL AA DA",
+      "5Ptas. 1.8 Nafta CD",
+      "5Ptas. 1.8 Nafta Easytronic"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 74,
+    "modelo": "Corvette",
+    "versiones": [
+      "Z06 7.0",
+      "Coupe"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 75,
+    "modelo": "Cruze",
+    "versiones": [
+      "1.8 LT MT (141cv) 4Ptas.",
+      "1.8 LT AT (141cv) 4Ptas.",
+      "1.8 LTZ MT (141cv) 4Ptas.",
+      "1.8 LTZ AT (141cv) 4Ptas.",
+      "2.0 VCDi LT MT (150cv) 4Ptas.",
+      "2.0 VCDi LT AT (163cv) 4Ptas.",
+      "2.0 VCDi LTZ MT (150cv) 4Ptas.",
+      "2.0 VCDi LTZ AT (163cv/150cv) 4Ptas.",
+      "1.8 LT MT (141cv) 5Ptas.",
+      "1.8 LTZ MT (141cv) 5Ptas.",
+      "1.8 LTZ AT (141cv) 5Ptas.",
+      "2.0 VCDi LT AT (163cvcv) 5Ptas.",
+      "2.0 VCDi LTZ AT (163cvcv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 76,
+    "modelo": "Cruze II",
+    "versiones": [
+      "1.4T LT MT (153cv) 4Ptas. (L20)",
+      "1.4T LT AT (153cv) 4Ptas. (L20)",
+      "1.4T LTZ (153cv) 4Ptas. (L20)",
+      "1.4T LTZ AT (153cv) 4Ptas. (L20)",
+      "1.4T Premier AT (153cv) 4Ptas. (L20)",
+      "1.4T Midnigth AT (153cv) 4Ptas. (L20)",
+      "1.4T LT MT (153cv) 5Ptas. (L20)",
+      "1.4T LT AT (153cv) 5Ptas. (L20)",
+      "1.4T LTZ AT (153cv) 5Ptas. (L20)",
+      "1.4T RS AT (153cv) 5Ptas. (L20)",
+      "1.4T Premier AT (153cv) 5Ptas. (L20)",
+      "1.4T MT LS (153cv) 4Ptas.",
+      "1.4T MT LT (153cv) 4Ptas.",
+      "1.4T MT LTZ (153cv) 4Ptas.",
+      "1.4T AT LTZ (153cv) 4Ptas.",
+      "1.4T AT LTZ Plus (153cv) 4Ptas.",
+      "1.4T MT LT (153cv) 5Ptas.",
+      "1.4T MT LTZ (153cv) 5Ptas.",
+      "1.4T AT LTZ (153cv) 5Ptas.",
+      "1.4T AT LTZ Plus (153cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 77,
+    "modelo": "Equinox",
+    "versiones": [
+      "1.5T LS 6AT FWD (172cv)",
+      "1.5T LT 6AT FWD (172cv)",
+      "1.5T RS 6AT FWD (172cv)",
+      "1.5T Premier 6AT AWD (172cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 78,
+    "modelo": "Meriva",
+    "versiones": [
+      "1.8 N 8v GL AA DA",
+      "1.8 N 8v GL Plus ABG",
+      "1.8 N 8v GLS",
+      "1.8 N 8v Easytronic",
+      "1.7 TD GLS"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 79,
+    "modelo": "Montana",
+    "versiones": [
+      "1.2T LT MT C/Doble (132cv)",
+      "1.2T LTZ AT C/Doble (132cv)",
+      "1.2T RS AT C/Doble (132cv)",
+      "1.2T Premier AT C/Doble (132cv)",
+      "1.8 8v. LS Base (105cv)",
+      "1.8 8v. LS AA DA (105cv)",
+      "1.8 8v. LS Pack (105cv)",
+      "1.8 8v. LTZ Sport (105cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 80,
+    "modelo": "Onix",
+    "versiones": [
+      "JOY PLUS 1.4 8v MT (98cv) 4Ptas. (L20)",
+      "JOY PLUS 1.4 8v MT Black (98cv) 4Ptas. (L20)",
+      "JOY 1.4 8v MT (98cv) 5Ptas. (L20)",
+      "JOY 1.4 8v MT Black (98cv) 5Ptas. (L20)",
+      "Plus 1.2 MT LS (90cv) (L20) 4Ptas.",
+      "Plus 1.2 MT LT (90cv) (L20) 4Ptas.",
+      "Plus 1.2 MT LT Tech (90cv) (L20) 4Ptas.",
+      "Plus 1.2 MT LT Tech Onstar (90cv) (L20) 4Ptas.",
+      "Plus 1.0T MT LT (116cv) (L20) 4Ptas.",
+      "Plus 1.0T MT LTZ (116cv) (L20) 4Ptas.",
+      "Plus 1.0T AT LTZ (116cv) (L20) 4Ptas.",
+      "Plus 1.0T MT Premier (116cv) (L20) 4Ptas.",
+      "Plus 1.0T AT Premier (116cv) (L20) 4Ptas.",
+      "1.2 MT LS (90cv) (L20) 5Ptas.",
+      "1.2 MT LT (90cv) (L20) 5Ptas.",
+      "1.2 MT LT Tech (90cv) (L20) 5Ptas.",
+      "1.2 MT LT Tech Onstar (90cv) (L20) 5Ptas.",
+      "1.0T MT LT (116cv) (L20) 5Ptas.",
+      "1.0T MT RS (116cv) (L20) 5Ptas.",
+      "1.0T MT LTZ (116cv) (L20) 5Ptas.",
+      "1.0T AT LTZ (116cv) (L20) 5Ptas.",
+      "1.0T MT Premier I (116cv) (L20) 5Ptas.",
+      "1.0T AT Premier II (116cv) (L20) 5Ptas.",
+      "1.4 8v Joy LS MT (Plan) (98cv)",
+      "1.4 8v Joy LS+ MT (98cv)",
+      "1.4 8v LT MT (98cv)",
+      "1.4 8v LTZ MT (98cv)",
+      "1.4 8v LTZ AT (98cv)",
+      "1.4 8v Effect (98cv)",
+      "Activ 1.4 8v (98cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 81,
+    "modelo": "Prisma",
+    "versiones": [
+      "1.4 Joy LS MT (98cv) (Plan)",
+      "1.4 Joy LS+ MT (98cv) (Plan)",
+      "1.4 LS MT (92cv)",
+      "1.4 8v LT MT (98cv)",
+      "1.4 LT MT (92cv)",
+      "1.4 8v LTZ MT (98cv)",
+      "1.4 8v LTZ AT (98cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 83,
+    "modelo": "S-10",
+    "versiones": [
+      "2.8 TD C/Simple 4x2 STD ABS (L09)",
+      "2.8 TD C/Doble 4x2 STD (L01)",
+      "2.8 TD C/Doble 4x2 STD ABS (L09)",
+      "2.8 TD C/Doble 4x2 DLX ABS (L09)",
+      "2.8 TD C/Doble 4x4 STD AA ABS (L09)",
+      "2.8 TD C/Doble 4x4 DLX ABS (L09)",
+      "2.8 TD C/Doble 4x4 LTD",
+      "2.8 CTDI C/Simple 4x2 LS (180cv) (L12)",
+      "2.8 CTDI C/Simple 4x4 LS (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x2 LS (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x2 LT (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x2 LTZ (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x2 High Country (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 LS (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 LT (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 LTZ MT (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 LTZ AT (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 High Country (180cv) (L12)",
+      "2.8 CTDI C/Doble 4x4 High Country AT (180cv) (L12)",
+      "2.8 CTDI C/Simple 4x2 LS (200cv) (L16)",
+      "2.8 CTDI C/Simple 4x4 LS (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 LS (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 LT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 LTZ (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 Midnight (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 High Country (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x2 100 Years (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 LS (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 LT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 LT AT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 LTZ MT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 LTZ AT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 Midnight (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 High Country (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 High Country AT (200cv) (L16)",
+      "2.8 CTDI C/Doble 4x4 100 Years AT (200cv) (L16)",
+      "2.8 CTDI C/Simple 4x2 LS (200cv) (L20)",
+      "2.8 CTDI C/Simple 4x4 LS (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x2 LS (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x2 LT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x2 LTZ (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 LT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 LT AT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 LT Midnight AT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 LTZ AT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 High Country AT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x4 Z71 AT (200cv) (L20)",
+      "2.8 CTDI C/Doble 4x2 WT MT6 (200cv) (L25)",
+      "2.8 CTDI C/Doble 4x4 WT MT6 (200cv) (L25)",
+      "2.8 CTDI C/Doble 4x4 WT AT8 (200cv) (L25)",
+      "2.8 CTDI C/Doble 4x4 Z71 AT8 (200cv) (L25)",
+      "2.8 CTDI C/Doble 4x4 LTZ AT8 (200cv) (L25)",
+      "2.8 CTDI C/Doble 4x4 High Country AT8 (200cv) (L25)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 691,
+    "modelo": "Silverado",
+    "versiones": [
+      "5.3 V8 Z71 Trail Boss AT10 (360cv)",
+      "5.3 V8 High Country AT10 (360cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 84,
+    "modelo": "Sonic",
+    "versiones": [
+      "1.6 LT (115cv) 4Ptas.",
+      "1.6 LTZ (115cv) 4Ptas.",
+      "1.6 LTZ AT Sec. (115cv) 4Ptas.",
+      "1.6 LT (115cv) 5Ptas.",
+      "1.6 LTZ MT (115cv) 5Ptas.",
+      "1.6 LTZ AT Sec. (115cv) 5Ptas.",
+      "1.6 Effect MT (115cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 85,
+    "modelo": "Spark",
+    "versiones": [
+      "LS 1.0 5Ptas. (L08)",
+      "LT 1.0 5Ptas. (L08)",
+      "LT 1.2 ABG ABS (81cv) (L11)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 86,
+    "modelo": "Spin",
+    "versiones": [
+      "1.8 8v LT MT 5as. (105cv) (L21)",
+      "1.8 8v Premier MT 7as. (105cv) (L21)",
+      "1.8 8v Premier AT 7as. (105cv) (L21)",
+      "Activ 1.8 8v AT 7as. (105cv) (L21)",
+      "1.8 8v LT MT 5as. (105cv) (L18)",
+      "1.8 8v LTZ MT 5as. (105cv) (L18)",
+      "1.8 8v LTZ MT 7as. (105cv) (L18)",
+      "1.8 8v LTZ AT 7as. (105cv) (L18)",
+      "1.8 8v Activ MT 5as. (105cv) (L18)",
+      "1.8 8v Activ AT 5as. (105cv) (L18)",
+      "1.8 8v Activ AT 7as. (105cv) (L18)",
+      "1.8 8v LT MT 5as. (105cv)",
+      "1.8 8v LTZ MT 5as. (105cv)",
+      "1.8 8v LTZ MT 7as. (105cv)",
+      "1.8 8v LTZ AT 7as. (105cv)",
+      "1.8 8v Activ MT 5as. (105cv)",
+      "1.8 8v Activ AT 5as. (105cv)",
+      "1.3 TD LTZ MT 5as. (75cv)",
+      "1.3 TD LTZ MT 7as. (75cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 87,
+    "modelo": "Tracker",
+    "versiones": [
+      "1.2T MT 4x2 (132cv)",
+      "1.2T AT 4x2 (132cv)",
+      "1.2T LTZ AT 4x2 (132cv)",
+      "1.2T Premier AT 4x2 (132cv)",
+      "1.2T RS AT 4x2 (132cv)",
+      "1.8 Premier MT 4x2 (140cv)",
+      "1.8 Midnight MT 4x2 (140cv)",
+      "1.8 Premier AT 4x4 (140cv)",
+      "1.8 Premier+ AT 4x4 (140cv)",
+      "1.8 LTZ MT 4x2 (140cv)",
+      "1.8 LTZ AT 4x4 (140cv)",
+      "1.8 LTZ+ AT 4x4 (140cv)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 88,
+    "modelo": "TrailBlazer",
+    "versiones": [
+      "2.8 CTDI 4x4 LT AT (180cv)",
+      "2.8 CTDI 4x4 LTZ (180cv)",
+      "2.8 CTDI 4x4 Premier AT (200cv)",
+      "2.8 TD 4x4 Premier AT (200cv)",
+      "2.8 TD 4x4 High Country AT (207cv) (L25)"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 82,
+    "modelo": "Vectra",
+    "versiones": [
+      "4Ptas. 2.0 GLS 8v",
+      "4Ptas. 2.4 GLS 16v",
+      "4Ptas. 2.4 CD MT 16v",
+      "4Ptas. 2.4 CD AT 16v",
+      "5Ptas. GT 2.0 GLS 8v",
+      "5Ptas. GT 2.4 CD MT 16v",
+      "5Ptas. GT 2.4 CD AT 16v"
+    ]
+  },
+  {
+    "marca": "CHEVROLET",
+    "modeloId": 89,
+    "modelo": "Zafira",
+    "versiones": [
+      "GL 2.0 8v",
+      "GLS 2.0 16v"
+    ]
+  },
+  {
+    "marca": "CHRYSLER",
+    "modeloId": 90,
+    "modelo": "300",
+    "versiones": [
+      "300C 3.5 N V6 (249hp)",
+      "300C 3.6L Pentastar V6 (286hp)",
+      "300C 5.7 N V8 HEMI (346hp)"
+    ]
+  },
+  {
+    "marca": "CHRYSLER",
+    "modeloId": 92,
+    "modelo": "Grand Caravan",
+    "versiones": [
+      "Town & Country 3.8 AT Ltd."
+    ]
+  },
+  {
+    "marca": "CHRYSLER",
+    "modeloId": 93,
+    "modelo": "PT Cruiser",
+    "versiones": [
+      "2.4 Touring AutoStick (143cv)",
+      "2.4 Classic MT (143cv)",
+      "2.4 Classic AutoStick (143cv)"
+    ]
+  },
+  {
+    "marca": "CHRYSLER",
+    "modeloId": 91,
+    "modelo": "Town & Country",
+    "versiones": [
+      "Limited 3.6 ATX V6 (287hp)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 699,
+    "modelo": "Basalt",
+    "versiones": [
+      "1.6 Like Pk (115cv)",
+      "1.6 Feel (115cv)",
+      "1.0T Shine CVT (120cv)",
+      "1.0T First Edition CVT (120cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 94,
+    "modelo": "Berlingo",
+    "versiones": [
+      "Furgón 1.4i N Club (L14)",
+      "Furgón 1.4i N (L10)",
+      "Furgón 1.4i N Fulll (L10)",
+      "Furgón 1.6 VTI Business (115cv) (L17)",
+      "Furgón 1.4i N Business (L14)",
+      "Furgón 1.6 VTI Business Mixto (115cv) (L17)",
+      "Furgón 1.4i N Business Mixto(L14)",
+      "Furgón 1.4i N Pack Seguridad CCP (L10)",
+      "Furgón 1.4i N Pack PLC (L10)",
+      "Furgón 1.6 HDI (L10)",
+      "Furgón 1.6 HDI PLC (L10)",
+      "Furgón 1.6 HDI Business (92cv) (L17)",
+      "Furgón 1.6 HDI Business (L14)",
+      "Furgón 1.6 HDI Business Mixto (92cv) (L17)",
+      "Furgón 1.6 HDI Business Mixto (L14)",
+      "Furgón 1.6 HDI PLC Full (L10)",
+      "Furgón 1.6 HDI PLC Pack Seguridad CCP (L10)",
+      "Multispace 1.4i N (L10)",
+      "Multispace 1.4i N X (L10)",
+      "Multispace 1.6 N X (L10)",
+      "Multispace 1.6 N PC Abordo (L10)",
+      "Multispace 1.6 N SX (L10)",
+      "Multispace 1.6 N SX Pack (L10)",
+      "Multispace 1.6 VTI XTR (115cv) (L17)",
+      "Multispace 1.6 N 110 XTR (L10)",
+      "Multispace 1.6 HDI SX (L10)",
+      "Multispace 1.6 HDI SX Pack (L10)",
+      "Multispace 1.6 HDI PC Abordo (L10)",
+      "Multispace 1.6 HDI XTR (92cv) (L17)",
+      "Multispace 1.6 HDI 92 XTR (L10)",
+      "Furgón 1.9 D Full",
+      "Multispace 1.9 D Full PLC DAB",
+      "Multispace 1.9 D Pack 2PLC AA"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 109,
+    "modelo": "C-ELYSÉE",
+    "versiones": [
+      "1.6 16v Live MT (115cv)",
+      "1.6 16v Feel MT (115cv)",
+      "1.6 16v Feel AT (115cv)",
+      "1.6 HDI Feel (92cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 95,
+    "modelo": "C3",
+    "versiones": [
+      "1.0T You! CVT (120cv)",
+      "1.6 Feel MT (115cv) (L24)",
+      "1.6 Feel Pack AT (115cv) (L24)",
+      "1.6 Feel Pack AT Bitono (115cv) (L24)",
+      "1.2 PureTech Live MT (82cv) (L22)",
+      "1.2 PureTech Live Pack MT (82cv) (L22)",
+      "1.2 PureTech Feel MT (82cv) (L22)",
+      "1.2 PureTech Feel Confort (82cv) (L22)",
+      "1.2 PureTech First Edition MT (82cv) (L22)",
+      "1.2 PureTech Feel Design (82cv) (L22)",
+      "1.2 PureTech Feel LOOK (82cv) (L22)",
+      "1.6 Feel MT (115cv) (L22)",
+      "1.6 Feel Confort MT (115cv) (L22)",
+      "1.6 Feel Pack AT6 (115cv) (L22)",
+      "1.6 Feel Pack AT6 Bitono (115cv) (L22)",
+      "1.6 First Edition AT6 (115cv) (L22)",
+      "1.6 Feel LOOK AT6 (115cv) (L22)",
+      "1.6 Feel LOOK Bitono AT6 (115cv) (L22)",
+      "1.6 Feel Pack Design AT6 (115cv) (L22)",
+      "1.6 Feel Pack Design Bitono AT6 (115cv) (L22)",
+      "1.5i 90 Start (L16)",
+      "1.5i 90 Live (L16)",
+      "1.5i 90 Feel (L16)",
+      "1.6 VTi 115 Live (L16)",
+      "1.6 VTi 115 Techno (L16)",
+      "1.6 VTi 115 Feel (L16)",
+      "1.6 VTi 115 Feel Bitono (L16)",
+      "1.6 VTi 115 Feel AT (L16)",
+      "1.6 VTi 115 Feel AT Bitono (L16)",
+      "1.6 VTi 115 Origins (L16)",
+      "1.6 VTi 115 Shine (L16)",
+      "1.6 VTi 115 Shine AT (L16)",
+      "1.6 VTi 115 Infinit AT (L16)",
+      "1.6 VTi 115 Urban Trail (L16)",
+      "1.6 VTi 115 Urban Trail AT (L16)",
+      "1.5i 90 Origine (L12)",
+      "1.5i 90 Origine Pack Zenith (L12)",
+      "1.5i 90 Tendance (L12)",
+      "1.5i 90 Tendance Pack Secure (L12)",
+      "1.5i 90 Soundtrack (L12)",
+      "1.6 VTi 115 Exclusive (L12)",
+      "1.6 VTi 115 Exclusive Pack My Way (L12)",
+      "1.4i SX",
+      "1.4i SX Pack Style (L08)",
+      "1.4i SX Pack XTR (L08)",
+      "1.4i SX Pack Seguridad (L08)",
+      "1.4i SX Pack Premium (L08)",
+      "1.4i XTR (L08)",
+      "1.6i SX (L08)",
+      "1.6i Exclusive",
+      "1.4 HDi Exclusive"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 96,
+    "modelo": "C3 AirCross",
+    "versiones": [
+      "1.6 Live MT 5pas. (115cv) (L24)",
+      "1.6 Feel Pack MT 5pas. (115cv) (L24)",
+      "1.6 Feel Pack MT 7Pas.(115cv) (L24)",
+      "1.0T T200 Feel CVT (120cv) (L24)",
+      "1.0T T200 Feel Pack CVT 5pas. (120cv) (L24)",
+      "1.0T T200 Feel CVT 7Pas. (120cv) (L24)",
+      "1.0T T200 Shine CVT 5pas. (120cv) (L24)",
+      "1.0T T200 Shine CVT 7Pas. (120cv) (L24)",
+      "1.5 Live (90cv) (L16)",
+      "1.6 Live (115cv)",
+      "1.6 Feel (115cv) (L16)",
+      "1.6 Feel AT (115cv) (L16)",
+      "1.6 Shine (115cv) (L16)",
+      "1.6 Shine W (115cv) (L16)",
+      "1.6 Shine AT (115cv) (L16)",
+      "1.6 Urban Edition (115cv) (L16)",
+      "1.6 VTi 115 Tendance (L13)",
+      "1.6 VTi 115 Exclusive (L13)",
+      "1.6 VTi 115 Exclusive My Way (L13)",
+      "1.6 16v (110cv) (L11)",
+      "1.6 16v X Pack Seguridad (110cv) (L11)",
+      "1.6 16v SX (110cv) (L11)",
+      "1.6 16v SX High Tech (110cv) (L11)",
+      "1.6 16v Exclusive (110cv) (L11)",
+      "1.6 16v Exclusive Pack My Way (110cv) (L11)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 97,
+    "modelo": "C3 Picasso",
+    "versiones": [
+      "1.5i 90 Origine (L13)",
+      "1.6 VTi 115 Tendance (L13)",
+      "1.6 VTi 115 Exclusive (L13)",
+      "1.6 VTi 115 Exclusive Pack My Way (L13)",
+      "1.6 16v (L11)",
+      "1.6 16v SX (L11)",
+      "1.6i 16v Exclusive (L11)",
+      "1.6i 16v Exclusive Pack My Way (L11)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 98,
+    "modelo": "C4",
+    "versiones": [
+      "4Ptas.- 2.0i 16v X (143cv)",
+      "4Ptas.- 2.0i 16v X Pack Look (143cv)",
+      "4Ptas.- 2.0i 16v SX (143cv)",
+      "4Ptas.- 2.0i 16v SX Cuero (143cv)",
+      "4Ptas.- 2.0i 16v SX AT (BVA) (143cv)",
+      "4Ptas.- 2.0i 16v Exclusive (143cv)",
+      "4Ptas.- 2.0i 16v Exclusive AT (BVA) (143cv)",
+      "4Ptas.- 1.6 Hdi SX (115cv)",
+      "4Ptas.- 1.6 Hdi SX Cuero (115cv)",
+      "4Ptas.- 2.0 Hdi SX (110cv)",
+      "4Ptas.- 2.0 Hdi SX Cuero (110cv)",
+      "5Ptas.- 1.6 16v X (110cv)",
+      "5Ptas.- 1.6 16v X Pack Look (110cv)",
+      "5Ptas.- 1.6 16v X Pack Connect (110cv)",
+      "5Ptas.- 1.6 16v X Pack Plus (110cv)",
+      "5Ptas.- 2.0i 16v SX (143cv)",
+      "5Ptas.- 2.0i 16v Exclusive (143cv)",
+      "5Ptas.- 2.0i 16v Exclusive AT (BVA) (143cv)",
+      "5Ptas.- 1.6 Hdi SX",
+      "5Ptas.- 2.0 Hdi X (110cv)",
+      "5Ptas.- 2.0 Hdi Exclusive (110cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 99,
+    "modelo": "C4 Aircross",
+    "versiones": [
+      "2.0 Tendance 4x2 MT (150cv)",
+      "2.0 Tendance 4x2 CVT (150cv)",
+      "2.0 Tendance 4x4 CVT (150cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 100,
+    "modelo": "C4 Cactus",
+    "versiones": [
+      "1.6 Live (115cv) (L18)",
+      "1.6 X-Series (115cv) (L18)",
+      "1.6 X-Series 6AT (115cv) (L18)",
+      "1.6 Feel (115cv) (L18)",
+      "1.6 Feel Pack (115cv) (L18)",
+      "1.6 Feel Pack Plus (115cv) (L18)",
+      "1.6 Feel Pack Plus Bitono (115cv) (L18)",
+      "1.6 Feel AT (115cv) (L23)",
+      "1.6 Feel+ AT (115cv) (L23)",
+      "1.6 Feel+ AT Bitono (115cv) (L23)",
+      "1.6 Feel Pack AT (115cv) (L18)",
+      "1.6 Feel Pack Plus AT (115cv) (L18)",
+      "1.6 Feel Pack Plus AT Bitono (115cv) (L18)",
+      "1.6 Feel Pack LOOK (115cv) (L18)",
+      "1.6 Feel Pack LOOK AT (115cv) (L18)",
+      "1.6 C-Series (115cv)",
+      "1.6 C-Series AT (115cv)",
+      "1.6 Rip Curl (115cv) (L18)",
+      "1.6 Rip Curl 6AT (115cv) (L18)",
+      "1.6 Origins (115cv) (L18)",
+      "1.6 THP Shine AT (165cv) (L18)",
+      "1.6 THP Shine AT Bitono (165cv) (L18)",
+      "1.6 THP Noir AT 165cv) (L18)",
+      "1.2 Puretech S&S AT6 Shine (110cv)",
+      "1.2 Puretech S&S AT6 Shine Bitono (110cv)",
+      "1.2 Puretech S&S AT6 Rip Curl (110cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 104,
+    "modelo": "C4 Grand Picasso",
+    "versiones": [
+      "1.6i THP 6AT Feel Pack (165cv)",
+      "1.6i THP 6AT Shine (165cv)",
+      "1.6 HDI 6MT Shine (115cv)",
+      "2.0i AT SX (BVA)",
+      "1.6 HDI Tendance Pack / SX"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 101,
+    "modelo": "C4 Lounge",
+    "versiones": [
+      "1.6 VTi 6MT Live (115cv) (L18)",
+      "1.6 THP 6MT Feel (165cv) (L18)",
+      "1.6 THP 6MT Feel Pack (165cv) (L18)",
+      "1.6 THP 6AT Feel (165cv) (L18)",
+      "1.6 THP 6AT Shine (165cv) (L18)",
+      "1.6i HDI 6MT Feel Pack (115cv) (L18)",
+      "1.6i HDI 6MT Origins (115cv) (L18)",
+      "1.6 THP 6MT Feel (165cv) (L16)",
+      "1.6 THP 6MT Feel Pack (165cv) (L16)",
+      "1.6 THP 6AT Feel (165cv) (L16)",
+      "1.6 THP 6MT S Edition (165cv) (L16)",
+      "1.6 THP 6MT Pack 10 Años (165cv) (L16)",
+      "1.6 THP 6AT Shine (165cv) (L16)",
+      "2.0i 6MT Live (143cv) (L16)",
+      "2.0i 6MT Feel Pack (143cv) (L16)",
+      "1.6 HDI 6MT Feel Pack (115cv) (L16)",
+      "1.6 HDI 6MT Pack 10 Años (115cv) (L16)",
+      "1.6i THP MT S (165cv)",
+      "1.6i THP 6MT Tendance (165cv)",
+      "1.6i THP 6AT Tendance S/Nav. (163cv)",
+      "1.6i THP 6AT Tendance (165cv)",
+      "1.6i THP 6AT Exclusive (165cv)",
+      "1.6i THP 6AT Exclusive P.Select (163cv)",
+      "2.0i Origine (143cv)",
+      "2.0i Tendance (143cv)",
+      "2.0i Tendance Pack (143cv)",
+      "1.6 HDI Tendance (115cv)",
+      "1.6 HDI Tendance Pack (115cv)",
+      "1.6 HDI Exclusive (115cv)",
+      "1.6 HDI Exclusive P.Select (115cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 102,
+    "modelo": "C4 Picasso",
+    "versiones": [
+      "1.6i THP 6AT Feel (165cv)",
+      "1.6i THP 6AT Feel Pack (165cv)",
+      "2.0i 16v BVA Tendance NAV",
+      "1.6i HDI 6MT Feel (115cv)",
+      "1.6i HDI 6MT Feel Pack (115cv)",
+      "1.6 HDi Origine",
+      "1.6 HDi Tendance NAV"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 103,
+    "modelo": "C4 Spacetourer",
+    "versiones": [
+      "1.6 THP 6AT Feel (165cv)",
+      "1.6 THP 6AT Feel Pack (165cv)",
+      "1.6 THP 6AT Rip Curl (165cv)",
+      "1.6i HDI 6MT Feel (115cv)",
+      "1.6i HDI 6MT Feel Pack (115cv)",
+      "1.6i HDI 6MT Rip Curl (115cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 106,
+    "modelo": "C5",
+    "versiones": [
+      "1.6 THP Exclusive (156cv) (L10)",
+      "2.0i Confort (143cv) (L10)",
+      "2.0 HDI Confort (138cv) (L10)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 107,
+    "modelo": "C5 Aircross",
+    "versiones": [
+      "1.6 6AT Feel Pack (165cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 108,
+    "modelo": "C6",
+    "versiones": [
+      "3.0i V6 Exclusive BVA"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 105,
+    "modelo": "Grand C4 Spacetourer",
+    "versiones": [
+      "1.6 THP 6AT Feel Pack (165cv)",
+      "1.6 THP 6AT Shine (165cv)",
+      "1.6i HDI 6MT Shine (115cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 110,
+    "modelo": "Jumper",
+    "versiones": [
+      "2.2 HDI MT6 L2H1 435 (130cv) (L17)",
+      "2.2 HDI MT6 L2H2 435 (130cv) (L17)",
+      "2.2 HDI MT6 L3H2 435 (130cv) (L17)",
+      "2.2 HDI MT6 L3 435 Chasis (130cv) (L17)",
+      "2.2 HDI MT6 L3 440 Chasis (130cv) (L17)",
+      "2.2 HDI MT6 L4H2 440 Minibus 17+1 (130cv) (L17)",
+      "II - 2.3 HDI M (MY16)",
+      "II - 2.3 HDI MH Alto (MY16)",
+      "II - 2.3 HDI LH Largo (MY16)",
+      "II - 2.3 HDI M Pack (L10)",
+      "II - 2.3 HDI MH Alta (L10)",
+      "II - 2.3 HDI LH Larga (L15)",
+      "Furgón 2.8 HDI Pack ABS"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 111,
+    "modelo": "Jumpy",
+    "versiones": [
+      "1.5TD MT6 (120cv)",
+      "1.6 HDI 6MT Busines (115cv)",
+      "1.6 HDI 6MT Busines Mixto (115cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 112,
+    "modelo": "Spacetourer",
+    "versiones": [
+      "2.0 HDi 6AT 8 Pas. Feel (150cv)",
+      "2.0 HDi 6AT 8 Pas. Feel Pack (150cv)"
+    ]
+  },
+  {
+    "marca": "CITROEN",
+    "modeloId": 113,
+    "modelo": "Xsara Picasso",
+    "versiones": [
+      "1.6i 16v  Nivel I",
+      "1.6i 16v Exclusive (L07)",
+      "2.0i 16v Exclusive (138cv-118cv)",
+      "2.0i 16v AT BVA (138cv) (L07)",
+      "2.0 HDi Exclusive (L07)"
+    ]
+  },
+  {
+    "marca": "CORADIR",
+    "modeloId": 114,
+    "modelo": "Chiki",
+    "versiones": [
+      "70 KM",
+      "110 KM"
+    ]
+  },
+  {
+    "marca": "CORADIR",
+    "modeloId": 115,
+    "modelo": "Tita",
+    "versiones": [
+      "100KM",
+      "100KM AA",
+      "300KM",
+      "300KM AA"
+    ]
+  },
+  {
+    "marca": "CORADIR",
+    "modeloId": 116,
+    "modelo": "Tita Cuadrilla",
+    "versiones": [
+      "100 4Ptas.",
+      "100 AA 4Ptas.",
+      "300 4Ptas.",
+      "300 AA 4Ptas."
+    ]
+  },
+  {
+    "marca": "CORADIR",
+    "modeloId": 117,
+    "modelo": "Tito",
+    "versiones": [
+      "S2 - 100",
+      "S2 - 100 AA",
+      "S5 - 100",
+      "S5 - 100 AA",
+      "S5 - 100 Potenciado",
+      "S5 - 300 AA",
+      "S5 - 300 Potenciado"
+    ]
+  },
+  {
+    "marca": "DODGE",
+    "modeloId": 118,
+    "modelo": "Journey",
+    "versiones": [
+      "SE 2.4 2 Filas",
+      "SXT 2.4 2 Filas",
+      "SXT 2.4 3 Filas",
+      "SXT 2.4 3 Filas 6AT - Techo",
+      "RT 2.7 s/Techo",
+      "RT 2.7 Full DVD",
+      "RT 3.6 ATX AWD (280hp)"
+    ]
+  },
+  {
+    "marca": "DODGE",
+    "modeloId": 354,
+    "modelo": "Ram",
+    "versiones": [
+      "2500 SLT TD AT 4x4 C/Doble (325hp)",
+      "2500 Laramie TD AT 4x4 C/Doble (325hp)"
+    ]
+  },
+  {
+    "marca": "DS",
+    "modeloId": 119,
+    "modelo": "DS3",
+    "versiones": [
+      "1.2T PureTech AT8 RIVOLI (130cv)",
+      "1.2T PureTech AT8 RIVOLI+ (130cv)",
+      "1.2T PureTech AT6 SO CHIC (110cv) Cabrio",
+      "1.2T PureTech AT6 SO CHIC (110cv)",
+      "1.2T PureTech AT6 Performance Line (110cv)",
+      "1.2T PureTech AT6 CAFE RACER (110cv)",
+      "1.2T PureTech AT6 DARK SIDE (110cv)",
+      "1.6 VTi BE CHIC (120cv)",
+      "1.6 VTi Givenchy (120cv)",
+      "1.6 VTi SO CHIC (120cv)",
+      "1.6 VTi 1955 (120cv)",
+      "1.6T MT Sport Chic Nav. (165/156cv)",
+      "1.6 THP 6MT S&S Performance (208cv)",
+      "CrossBack 1.2T PureTech AT6 BE CHIC (155cv)",
+      "CrossBack 1.2T PureTech AT6 SO CHIC (155cv)",
+      "CrossBack 1.2T PureTech AT6 GRAND CHIC (155cv)",
+      "CrossBack 1.2T PureTech AT6 RIVOLI (155cv) (L22)",
+      "CrossBack 1.2T PureTech AT6 RIVOLI (155cv)",
+      "CrossBack 1.2T PureTech AT6 RIVOLI+ (155cv)"
+    ]
+  },
+  {
+    "marca": "DS",
+    "modeloId": 120,
+    "modelo": "DS4",
+    "versiones": [
+      "1.6 THP 6AT BE CHIC CB (163cv)",
+      "1.6 THP 6AT BE CHIC Pack CB / Inspiration (163cv)",
+      "1.6 THP 6AT SO CHIC (163cv)",
+      "1.6 THP 6MT S&S Performance (208cv)",
+      "1.6 T 8AT Performance Line (215cv)",
+      "1.6 T 8AT Trocadero (215cv)",
+      "1.6 T 8AT Étoile (215cv)",
+      "CrossBack 1.6 THP 6AT SO CHIC (163cv)"
+    ]
+  },
+  {
+    "marca": "DS",
+    "modeloId": 121,
+    "modelo": "DS7",
+    "versiones": [
+      "CrossBack 1.6T AT PureTech Performance Line (165cv)",
+      "CrossBack 1.6T AT PureTech BE CHIC (165cv)",
+      "1.6T AT8 E-Tense 4x4 PHEV (300cv)",
+      "1.6T AT8 Bastille (215cv)",
+      "1.6T AT8 Pallas (215cv)",
+      "1.6T AT8 Rivoli (215cv)",
+      "CrossBack 2.0 Hdi AT SO CHIC (180cv)",
+      "CrossBack 2.0 Hdi AT BASTILLE+ (180cv)",
+      "CrossBack 2.0 Hdi AT RIVOLI (180cv)",
+      "CrossBack 2.0 Hdi AT GRAND CHIC (180cv)",
+      "CrossBack 2.0 Hdi AT GRAND CHIC OPERA (180cv)",
+      "CrossBack E-Tense 4x4 300 BASTILLE+"
+    ]
+  },
+  {
+    "marca": "DS",
+    "modeloId": 122,
+    "modelo": "DS9",
+    "versiones": [
+      "1.6T 8AT (215cv)"
+    ]
+  },
+  {
+    "marca": "FAW",
+    "modeloId": 123,
+    "modelo": "Actis",
+    "versiones": [
+      "1.5 MT Truck (102cv)",
+      "1.5 MT Box (102cv)"
+    ]
+  },
+  {
+    "marca": "FAW",
+    "modeloId": 124,
+    "modelo": "T33",
+    "versiones": [
+      "1.2T AT7 (143cv)"
+    ]
+  },
+  {
+    "marca": "FAW",
+    "modeloId": 125,
+    "modelo": "X40",
+    "versiones": [
+      "1.6 AT6 (113cv)"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 127,
+    "modelo": "430",
+    "versiones": [
+      "430",
+      "430 F1",
+      "Spider 430",
+      "Scuderia"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 128,
+    "modelo": "458",
+    "versiones": [
+      "Italia",
+      "Spyder"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 129,
+    "modelo": "488",
+    "versiones": [
+      "GTB (670cv)",
+      "Spider (670cv)",
+      "Pista (721cv)"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 130,
+    "modelo": "599",
+    "versiones": [
+      "599",
+      "599 F1"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 131,
+    "modelo": "612",
+    "versiones": [
+      "Scaglietti",
+      "Scaglietti F1"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 132,
+    "modelo": "California",
+    "versiones": [
+      "2+2"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 133,
+    "modelo": "F12",
+    "versiones": [
+      "Berlinata"
+    ]
+  },
+  {
+    "marca": "FERRARI",
+    "modeloId": 134,
+    "modelo": "Portofino",
+    "versiones": [
+      "2+2"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 135,
+    "modelo": "500",
+    "versiones": [
+      "1.4 Pop Dualogic (100cv) (L08)",
+      "1.4 Sport MT (100cv) (L08)",
+      "1.4 Louge AT (100cv) (L08)",
+      "1.4 Diesel AT (100cv) (L08)",
+      "1.4 Sport MT Cuero EU5 (100cv) (L18)",
+      "1.4 Cult 8v MT (85cv) (L11)",
+      "1.4 Sport MultiAir MT (105cv) (L11)",
+      "1.4 Sport MultiAir MT Cuero TC (105cv) (L11)",
+      "1.4 Sport MultiAir AT (105cv) (L11)",
+      "1.4 Lounge AT Dualogic EU5 (100cv) (L18)",
+      "1.4 Lounge MultiAir AT (105cv) (L11)",
+      "1.4 Gucci MultiAir AT (105cv) (L11)",
+      "Abarth 1.4T (135cv)",
+      "Abarth 1.4T TC (135cv)",
+      "Abarth 1.4T As.Racing Cuero (135cv)",
+      "Abarth 1.4T 595 Turismo (165cv) (L18)",
+      "Abarth 1.4T 595 Turismo (160cv)",
+      "500C 1.4 MultiAir Lounge AT (105cv) Cabrio",
+      "500C 1.4 N Cabrio",
+      "500C 1.4 N Gucci Cabrio",
+      "500L 1.4 16v Pop star (95cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 136,
+    "modelo": "500X",
+    "versiones": [
+      "1.4T 6MT Pop Star 4x2 (140cv)",
+      "1.4T 9AT Cross 4x4 (170cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 137,
+    "modelo": "Argo",
+    "versiones": [
+      "1.3 Drive MT (99cv) (L25)",
+      "1.3 Drive MT (99cv)",
+      "1.3 Drive MT Pack Conectividad (99cv)",
+      "1.8 Precision MT (130cv)",
+      "1.8 Precision MT Pack Technology(130cv)",
+      "1.8 Precision MT Pack Premium (130cv)",
+      "1.8 Precision AT (130cv)",
+      "1.8 Precision AT Pack Technology(130cv)",
+      "1.8 Precision AT Pack Premium (130cv)",
+      "1.8 HGT MT (130cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 138,
+    "modelo": "Bravo",
+    "versiones": [
+      "1.4 MultiAir Dynamic (140cv)",
+      "1.4 MultiAir Sport (140cv)",
+      "1.4 MultiAir Sport Cuero Xenon (140cv)",
+      "1.6 Multijet Dynamic (120cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 139,
+    "modelo": "Cronos",
+    "versiones": [
+      "1.3 GSE Like MT (99cv) (MY23)",
+      "1.3 GSE Stile MT (99cv) (MY23) DISCONTINUO",
+      "1.3 GSE Attractive MT (99cv)",
+      "1.3 GSE Drive MT (99cv)",
+      "1.3 GSE Drive MT (99cv) (L23)",
+      "1.3 GSE Drive MT Pack Conectividad (99cv)",
+      "1.3 GSE Drive MT Pack Conectividad S-Desing (99cv)",
+      "1.3 GSE Drive MT Pack Plus (99cv) (MY23)",
+      "1.3 GSE Drive CVT (99cv)",
+      "1.3 GSE Drive Pack Plus CVT (99cv)",
+      "1.3 GSE Presicion CVT (99cv) (MY23)",
+      "1.8 MT Precision (130cv)",
+      "1.8 MT Precision Pack Technology (130cv)",
+      "1.8 MT Precision Pack Style (130cv)",
+      "1.8 MT Precision Pack Premium (130cv)",
+      "1.8 MT Precision Pack HTG (130cv)",
+      "1.8 AT Precision (130cv)",
+      "1.8 AT Precision Pack Technology (130cv)",
+      "1.8 AT Precision Pack Premium (130cv)",
+      "1.8 AT Centenario SL (130cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 140,
+    "modelo": "Dobló",
+    "versiones": [
+      "Cargo 1.4 16v. Active (95cv)",
+      "Cargo 1.4 16v. Active Pack Security ABS EBD (95cv)",
+      "Pasajero 1.4 16v. Active 5As. (95cv)",
+      "Pasajero 1.4 16v. 5As. Pack Security (95cv)",
+      "Pasajero 1.4 16v. Family 7As. (95cv)",
+      "Pasajero 1.4 16v. Family 7As. Pack Security (95cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 141,
+    "modelo": "Ducato",
+    "versiones": [
+      "2.3 Mjet Chasis (L19)",
+      "2.3 Mjet Furgon Corto L1H1 (L19)",
+      "2.3 Mjet Furgon Medio L2H1 (L19)",
+      "2.3 Mjet Maxicargo (L19)",
+      "2.3 Mjet Maxicargo Vidriado (L19)",
+      "2.3 Mjet Furgón Corto TN (L10)",
+      "2.3 Mjet Furgón Corto TN AA (L10)",
+      "2.3 Mjet Furgón Largo TN (L10)",
+      "2.3 Mjet Furgón Largo TN AA (L10)",
+      "2.3 Mjet Furgón Largo TE (L10)",
+      "2.3 Mjet Furgón Largo TE AA (L10)",
+      "2.3 Mjet Maxicargo TE (L10)",
+      "2.3 Mjet Maxicargo TE AA (L10)",
+      "2.3 Mjet Combinato (L10)",
+      "2.3 Mjet Combinato AA (L10)",
+      "2.3 Mjet Combinato Doble AA (L10)",
+      "2.8 JTD Furgón Techo Normal (L04)",
+      "2.8 JTD Furgón Techo Elevado (L04)",
+      "2.8 JTD Furgón Maxicargo Largo Techo Elevado (L04)",
+      "2.8 JTD Combinato 10 As. (L04)",
+      "2.8 JTD Minibus Maxicargo 14+1 (L04)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 142,
+    "modelo": "Fastback",
+    "versiones": [
+      "270 Turbo AT6 (175cv)",
+      "Abarth 270 Turbo AT6 (175cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 143,
+    "modelo": "Fiorino",
+    "versiones": [
+      "1.3 Fire Base",
+      "1.3 Fire Confort AA DA",
+      "1.4 8V Fire Evo (87cv) (L14)",
+      "1.4 8V Fire Evo Confort (87cv) (L14)",
+      "1.4 8V Fire Evo Top (87cv) (L14)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 144,
+    "modelo": "Fiorino QUBO",
+    "versiones": [
+      "1.4 8v. Active PLC",
+      "1.4 8v. Active PLC 2ABG",
+      "1.4 8v Confort / Dynamic PLC"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 154,
+    "modelo": "Grand Siena",
+    "versiones": [
+      "Attractive 1.4 MT",
+      "Attractive 1.4 MT Top",
+      "Essence 1.6 MT",
+      "Essence 1.6 Duallogic"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 145,
+    "modelo": "Idea",
+    "versiones": [
+      "Adventure 1.6 16v (115cv) (L10)",
+      "Adventure 1.6 16v Pack Tech / Top (115cv) (L10)",
+      "Adventure 1.6 16v Pack Locker (115cv) (L10)",
+      "Adventure 1.6 16v Cuero (115cv) (L10)",
+      "Adventure 1.8 Base / Serie (L10)",
+      "Adventure 1.8 AA DA / Confort (L10)",
+      "Adventure 1.8 Confort - Pack Xtreme ABS ABG",
+      "Adventure 1.8 Confort - Pack Seguridad (L10)",
+      "Adventure Locker 1.8 Confort (L10)",
+      "Adventure Locker 1.8 Confort / Pack Seguridad (L10)",
+      "1.4 8v. Attractive ABG ABS (82cv) (L10)",
+      "1.4 8v. Attractive Pack Top (82cv) (L10)",
+      "1.6 16v. Essence (115cv) (L10)",
+      "1.6 16v. Essence Pack Top (115cv) (L10)",
+      "1.6 16v. Sporting (115cv) (L10)",
+      "1.6 16v. Sporting Cuero (115cv) (L10)",
+      "1.4 8v. ELX Base",
+      "1.4 8v. ELX Top / Top II",
+      "1.8 HLX Emotion",
+      "1.8 HLX Emotion 2ABG"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 146,
+    "modelo": "Linea",
+    "versiones": [
+      "1.8 N 16v MT Essence (130cv) (L14)",
+      "1.8 N 16v Dualogic Essence (130cv)",
+      "1.8 N 16v MT Absolute (130cv) (L14)",
+      "1.8 N 16v Dualogic Absolute (130cv) (L14)",
+      "1.9 N 16v MT Essence (132cv)",
+      "1.9 N 16v Dualogic Essence (132cv)",
+      "1.9 N 16v MT Absolute (132cv)",
+      "1.9 N 16v Dualogic Absolute (132cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 147,
+    "modelo": "Mobi",
+    "versiones": [
+      "Treekking 1.0 MT (70cv)",
+      "1.0 Easy (75cv)",
+      "1.0 Easy Pack Top (75cv)",
+      "1.0 Easy Live On (75cv)",
+      "1.0 Like (75cv)",
+      "1.0 Way (75cv)",
+      "1.0 Way Live On (75cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 148,
+    "modelo": "Palio",
+    "versiones": [
+      "Attractive 1.4 5Ptas. (85cv) (L12)",
+      "Attractive 1.4 Pack Top 5Ptas. (85cv) (L12)",
+      "Essence 1.6 MT 5Ptas. (115cv) (L12)",
+      "Essence 1.6 AT Dualogic 5Ptas. (115cv) (L12)",
+      "Sporting 1.6 MT 5Ptas. (115cv) (L12)",
+      "Attractive (ELX) 1.4 Base 3Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 Active 3Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 Emotion 3Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 Base 5Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 Active 5Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 Emotion 5Ptas. (85cv) (L10)",
+      "Attractive (ELX) 1.4 GROOVE 5Ptas. (85cv) (L10)",
+      "Essence 1.6 16v. 5Ptas. (115cv) (L10)",
+      "Essence 1.6 16v. Active 5Ptas. (115cv) (L10)",
+      "Essence 1.6 16v. Emotion 2ABG ABS 5Ptas. (115cv) (L10)",
+      "Fire 1.4 Pack Confort 5Ptas.",
+      "Fire 1.4 Pack Top 5Ptas.",
+      "Fire 1.4 3Ptas.",
+      "Fire 1.4 3Ptas. Pack",
+      "Fire 1.4 5Ptas.",
+      "Fire 1.4 5Ptas. Pack",
+      "1.8R 5Ptas.",
+      "Weekend 1.4 Attractive (ELX) AA DA",
+      "Weekend 1.4 Attractive (ELX) Seguridad 2ABG ABS",
+      "Weekend 1.4 Attractive (ELX) Top / Class / Active II",
+      "Weekend 1.4 Trekking",
+      "Weekend 1.4 Trekking Active",
+      "Weekend 1.4 Trekking Seguridad 2ABG ABS"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 149,
+    "modelo": "Palio Adventure",
+    "versiones": [
+      "1.6 16v Serie (115cv)",
+      "1.6 16v Locker (115cv)",
+      "1.6 16v Seguridad (115cv)",
+      "1.6 16v Extreme (115cv)",
+      "1.6 16v Xtreme Locker (115cv)",
+      "1.8 Base / Active / Serie",
+      "1.8 Locker",
+      "1.8 Seguridad",
+      "1.8 Seguridad Locker",
+      "1.8 Xtreme ABS",
+      "1.8 Xtreme Locker"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 150,
+    "modelo": "Pulse",
+    "versiones": [
+      "1.3 Drive MT (99cv)",
+      "1.3 Drive CVT (99cv)",
+      "1.0T Audace CVT (130cv)",
+      "1.0T Impetus CVT (130cv)",
+      "1.3T Abarth AT6 (175cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 151,
+    "modelo": "Punto",
+    "versiones": [
+      "1.3 JTD ELX / Top (90cv)",
+      "1.4 Attractive 5Ptas. (87cv) (L13)",
+      "1.4 Attractive / ELX Base 5Ptas. (87cv)",
+      "1.4 Attractive Pack Top 5Ptas. (87cv) (L13)",
+      "1.4 Attractive / ELX Pack Top 5Ptas. (87cv)",
+      "1.6 16v MT Essence 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Essence 5Ptas. (115cv)",
+      "1.6 16v MT Essence Blue & Me / Techo 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Essence Pack Tech 5Ptas.",
+      "1.6 16v MT Essence Pack Tech TC 5Ptas.",
+      "1.6 16v MT Essence Emotion 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Essence Pack Emotion II 5Ptas.",
+      "1.6 16v Dualogic Essence 5Ptas. (115cv) (L13)",
+      "1.6 16v Dualogic Essence 5Ptas. (115cv)",
+      "1.6 16v Dualogic Essence Pack Emotion II 5Ptas. (115cv)",
+      "1.6 16v MT Sporting 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Sporting Pack Tech 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Sporting TC 5Ptas. (115cv) (L13)",
+      "1.6 16v MT Sporting TC y Cuero 5Ptas. (115cv) (L13)",
+      "1.6 16v AT Blackmotion 5Ptas. (115cv) (L13)",
+      "1.8 HLX 5Ptas. (112cv)",
+      "1.8 HLX Emotion II Techo 5Ptas. (112cv)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 152,
+    "modelo": "Qubo",
+    "versiones": [
+      "1.4 8v. Active",
+      "1.4 8v. Dynamic",
+      "1.4 8v. Trekiking"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 153,
+    "modelo": "Siena",
+    "versiones": [
+      "EL 1.4 Pack Seg. / AA DA (L10)",
+      "EL 1.4 Pack Attractive Active (L10)",
+      "EL 1.4 Pack Attractive Seguridad / Emotion (L10)",
+      "EL 1.6 16v Confort / Emotion (L14)",
+      "1.6 16v Essence Emotion (L10)",
+      "1.6 16v Essence High Tech (L10)",
+      "Fire RST II 1.4 Base DA (L07)",
+      "Fire RST II 1.4 AA DA (L07)",
+      "Fire RST II 1.4 Pack Way / Eléctrico (L07)",
+      "1.4 ELX Fire Active / Class / Suite (L06)",
+      "1.4 ELX Fire Pack Emotion (L06)",
+      "1.8 HLX Emotion / Class",
+      "1.8 HLX High Tech"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 155,
+    "modelo": "Stilo",
+    "versiones": [
+      "1.8 Active (L09)",
+      "1.8 Emotion (L09)",
+      "1.8 Executive (L09)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 156,
+    "modelo": "Strada",
+    "versiones": [
+      "1.3 8v Freedom Cab.Simple (99cv) (L24)",
+      "1.3 8v Freedom Cab.Doble (99cv) (L24)",
+      "1.3 8v Volcano CVT Cab.Doble (99cv) (L24)",
+      "1.3 8v Ranch CVT Cab.Doble (99cv) (L24)",
+      "1.0T Ultra CVT Cab.Doble (120cv) (L24)",
+      "1.4 8v Endurande Cab.Plus (85cv) (L20)",
+      "1.4 8v Endurande Cab.Doble (85cv) (L20)",
+      "1.4 8v Freedom Cab.Doble (85cv) (L20)",
+      "1.4 8v Freedom Tech Cab.Doble (85cv) (L20)",
+      "1.3 8v Volcano Cab.Doble (99cv) (L20)",
+      "1.3 8v Volcano CVT Cab.Doble (99cv) (L20)",
+      "1.3 8v Ranch CVT Cab.Doble (99cv) (L20)",
+      "Adventure C/Doble 2Ptas. 1.6 16v. Serie",
+      "Adventure C/Doble 2Ptas. 1.6 16v. Seguridad Pack Top (L14)",
+      "Adventure C/Doble 2Ptas. 1.6 16v. Techo Solar",
+      "Adventure C/Doble 2Ptas. 1.6 16v. Locker / Pack Extreme (L14)",
+      "Adventure C/Doble 3Ptas. 1.6 Pack Top / Serie",
+      "Adventure C/Doble 3Ptas. 1.6 16v. Pack Extreme",
+      "Adventure C/Doble 3Ptas. 1.6 16v. Techo Solar",
+      "Adventure C/Extendida 1.6 16v. Serie",
+      "Adventure C/Extendida 1.6 16v. Techo Solar",
+      "Adventure C/Extendida 1.6 16v. Locker / Pack Extreme (L14)",
+      "Adventure C/Extendida 1.6 16v. Seguridad Pack Top (L14)",
+      "Adventure C/Extendida 1.8 Serie",
+      "Adventure C/Extendida 1.8 Locker / Seguridad",
+      "Trekking C/Simple 1.3 JTD Serie",
+      "Trekking C/Simple 1.3 JTD AA Seg.",
+      "Trekking C/Simple 1.4 Serie",
+      "Trekking C/Simple 1.4 Seguridad (L14)",
+      "Trekking C/Extendida 1.3 JTD Top",
+      "Trekking C/Doble 3Ptas. 1.3 JTD Full (L14)",
+      "Working C/Simple 1.4 Serie",
+      "Working C/Simple 1.4 AA",
+      "Working C/Simple 1.4 AA Seguridad (L14)",
+      "Working C/Doble 1.4 AA Seguridad (L14)"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 157,
+    "modelo": "Tipo",
+    "versiones": [
+      "1.6 6AT Pop (110cv) 4Ptas.",
+      "1.6 6AT Easy (110cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 158,
+    "modelo": "Toro",
+    "versiones": [
+      "1.8 Freedom 4x2 AT6 Cab/Doble (130cv) (L21) DISCONTINUO",
+      "1.8 Freedom S-Design 4x2 AT6 Cab/Doble (130cv) (L21)",
+      "1.3T T270 Freedom 4x2 AT6 Cab/Doble (175cv) (L21)",
+      "1.3T T270 Volcano 4x2 AT6 Cab/Doble (175cv) (L21)",
+      "2.0TD TD350 Freedom 4x4 9AT Cab/Doble (L21)",
+      "2.0TD TD350 Volcano 4x4 9AT Cab/Doble (L21)",
+      "2.0TD TD350 Ultra 4x4 9AT Cab/Doble (L21)",
+      "2.0TD TD350 Ranch 4x4 9AT Cab/Doble (L21)",
+      "1.8 Freedom 4x2 AT6 Cab/Doble (130cv) (L19)",
+      "1.8 Freedom 4x2 AT6 Cab/Doble Pack Chrome (130cv) (L19)",
+      "2.0TD Freedom 4x4 9AT Cab/Doble (170cv) (L19)",
+      "2.0TD Freedom 4x4 9AT Cab/Doble Pack Seg. (170cv) (L19)",
+      "2.0TD Volcano 4x4 9AT Cab/Doble (170cv) (L19)",
+      "2.0TD Ranch 4x4 9AT Cab/Doble (170cv) (L19)",
+      "2.0 Freedom 4x2 6MT Cab/Doble",
+      "2.0 Freedom 4x4 6MT Cab/Doble",
+      "2.0 Freedom 4x4 6MT Cab/Doble Pack Extreme",
+      "2.0 Freedom 4x4 9AT Cab/Doble",
+      "2.0 Freedom 4x4 9AT Cab/Doble Pack Technology",
+      "2.0 Volcano 4x4 9AT Cab/Doble",
+      "2.0 Volcano 4x4 9AT Cab/Doble Pack Premium",
+      "2.0 BlackJack 4x4 9AT Cab/Doble"
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 159,
+    "modelo": "Uno",
+    "versiones": [
+      "Cargo Fire 1.3 Base (68cv) 3Ptas.",
+      "Cargo Fire 1.3 AA DA (68cv) 3Ptas.",
+      "Fire 1.3 Base (68cv) 3Ptas.",
+      "Fire 1.3 DA Pack 1 / Pack A (68cv) 3Ptas.",
+      "Fire 1.3 Pack 2 / Pack B / Pack Confort AA s/DA (68cv) 3Ptas.",
+      "Fire 1.3 Base (68cv) 5Ptas.",
+      "Fire 1.3 DA Pack 1 / Pack A (68cv) 5Ptas.",
+      "Fire 1.3 Pack 2 / Pack B / Confort AA s/DA (68cv) 5Ptas.",
+      "Fire 1.3 Pack C / Way (68cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 160,
+    "modelo": "Uno EVO",
+    "versiones": [
+      "Cargo 1.4 EVO (85cv)",
+      "Way 1.3 8v. MT (99cv) 5ptas.",
+      "Evo 1.4 Attractive (85cv) 3ptas.",
+      "Evo 1.4 Attractive Pack Eléctrico (85cv) 3ptas.",
+      "Evo 1.4 Attractive Pack Seguridad (85cv) 3ptas.",
+      "Evo 1.4 Attractive AA DA (85cv) 5ptas.",
+      "Evo 1.4 Attractive Pack Seg. (85cv) 5ptas.",
+      "Evo 1.4 Attractive Seguridad Pack Top (85cv) 5ptas.",
+      "Evo 1.4 Way (85cv) 5ptas.",
+      "Evo 1.4 Way Pack Seg. (85cv) 5ptas.",
+      "Evo 1.4 Way Seguridad Pack Top (85cv) 5ptas.",
+      "Evo 1.4 Sporting (85cv) 5ptas.",
+      "Evo 1.4 Sporting II Pack Seguridad (85cv) 5ptas."
+    ]
+  },
+  {
+    "marca": "FIAT",
+    "modeloId": 161,
+    "modelo": "Weekend",
+    "versiones": [
+      "1.4 Attractive",
+      "1.4 Attractive Pack Top",
+      "1.6 16v Adventure (115cv)",
+      "1.6 16v Adventure Locker (115cv)",
+      "1.6 16v Adventure Extreme (115cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 162,
+    "modelo": "Bronco",
+    "versiones": [
+      "2.7BT V6 AT10 Wildtrak (334cv)",
+      "Sport 1.5T Big Bend AT8 (184cv) (L25)",
+      "Sport 2.0T Badlands AT8 (253cv) (L25)",
+      "Sport 1.5T EcoBoost Big Bend AT8 (175cv) DISCONTINUO",
+      "Sport 2.0T EcoBoost Wildtrack AT8 (253cv) DISCONTINUO"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 707,
+    "modelo": "Cargo",
+    "versiones": null
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 163,
+    "modelo": "Courier",
+    "versiones": [
+      "Pick-up 1.6 N Base",
+      "Pick-up 1.6 N Plus"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 164,
+    "modelo": "EcoSport",
+    "versiones": [
+      "1.4 TDI XL Plus MP3 (L08)",
+      "1.4 TDI XLS MP3 (L08)",
+      "1.6 XL Plus MP3 (L08)",
+      "1.6 XLS MP3 (L08)",
+      "1.6 XLT Plus MP3 (L08)",
+      "1.6 XLT Freestyle (L08)",
+      "2.0 XLS (L08)",
+      "2.0 XLT Plus Cuero (L08)",
+      "2.0 XLT Plus AT Cuero (L08)",
+      "2.0 XLT 4X4 Plus Cuero (L08)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 165,
+    "modelo": "EcoSport KD",
+    "versiones": [
+      "1.5 S MT (123cv) (L18)",
+      "1.5 SE MT (123cv) (L18)",
+      "1.5 SE AT (123cv) (L18)",
+      "1.5 Freestyle MT (123cv) (L18)",
+      "1.5 Titanium MT (123cv) (L18)",
+      "1.5 Titanium AT (123cv) (L18)",
+      "2.0 SE AT (170cv) (L18)",
+      "2.0 Titanium AT (170cv) (L18)",
+      "2.0 Freestyle 4WD AT (170cv) (L18)",
+      "1.5 TDCi MT (100cv) (L18)",
+      "2.0 GDI Titanium AT (170cv) (L18)",
+      "STORM 2.0 4WD AT (170cv) (L18)",
+      "1.6 S MT (110cv)",
+      "1.6 SE MT (110cv)",
+      "1.6 Freestyle MT (110cv)",
+      "1.6 Titanium MT (110cv)",
+      "2.0 SE MT (143cv)",
+      "2.0 Titanium MT (143cv)",
+      "2.0 Titanium AT (143cv)",
+      "2.0 4x4 Freestyle MT (143cv)",
+      "1.5 TDCi MT S (90cv)",
+      "1.5 TDCi MT SE (90cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 166,
+    "modelo": "F-100",
+    "versiones": [
+      "3.9 TDI C/Simple 4x2 XL Plus",
+      "3.9 TDI C/Simple 4x2 XLT",
+      "3.9 TDI C/Simple 4x4 XL Plus",
+      "3.9 TDI C/Simple 4x4 XLT",
+      "3.9 TDI C/Doble 4x2 XLT",
+      "3.9 TDI C/Doble 4x4 XL Plus",
+      "3.9 TDI C/Doble 4x4 XLT"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 167,
+    "modelo": "F-150",
+    "versiones": [
+      "Lariat 5.0 AT 4x4 Luxury (400cv)",
+      "Tremor 5.0 AT 4x4 (400cv)",
+      "Lariat Luxury 3.5L V6 Híbrida 4x4 AT (400cv-45cv)",
+      "Raptor 3.5 Biturbo AT 4x4 (456cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 708,
+    "modelo": "F-4000",
+    "versiones": null
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 169,
+    "modelo": "Fiesta",
+    "versiones": [
+      "5Ptas. 1.6 N Energy / Fresh",
+      "5Ptas. 1.6 N Ambiente",
+      "5Ptas. 1.6 N Ambiente Plus / Ambiente AT",
+      "5Ptas. 1.6 N Edge / Plus",
+      "5Ptas. 1.6 N Edge Plus AT",
+      "5Ptas. 1.4 TD Ambiente / Plus",
+      "5Ptas. 1.4 TD Edge",
+      "Max 4Ptas. 1.6 N Fresh / Energy",
+      "Max 4Ptas. 1.6 N Ambiente / AT",
+      "Max 4Ptas. 1.6 N Ambiente Plus",
+      "Max 4Ptas. 1.6 N Edge Plus",
+      "Max 4Ptas. 1.4 TD Ambiente / Plus",
+      "Max 4Ptas. 1.4 TD Edge"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 168,
+    "modelo": "Fiesta KD",
+    "versiones": [
+      "1.6 S MT (120cv) 4Ptas.",
+      "1.6 S Plus MT (120cv) 4Ptas.",
+      "1.6 SE Plus MT (120cv) 4Ptas.",
+      "1.6 SE Plus Powershift (120cv) 4Ptas.",
+      "1.6 Titanium MT (120cv) 4Ptas.",
+      "1.6 Titanium Powershift (120cv) 4Ptas.",
+      "1.6 S MT (120cv) 5Ptas.",
+      "1.6 S Plus MT (120cv) 5Ptas.",
+      "1.6 SE MT (120cv) 5Ptas.",
+      "1.6 SE Powershift (120cv) 5Ptas.",
+      "1.6 SE Plus MT (120cv) 5Ptas.",
+      "1.6 SE Plus Powershift (120cv) 5Ptas.",
+      "1.6 Titanium MT (120cv) 5Ptas.",
+      "1.6 Titanium Powershift (120cv) 5Ptas.",
+      "1.6 Trend (120cv) 4Ptas. (L10)",
+      "1.6 Trend Plus (120cv) 4Ptas. (L10)",
+      "1.6 Trend (120cv) 5Ptas. (L10)",
+      "1.6 Titanium (120cv) 5Ptas. (L10)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 170,
+    "modelo": "Focus",
+    "versiones": [
+      "II EXE 4Ptas. 1.6 Sigma Style",
+      "II EXE 4Ptas. 1.6 Sigma Trend",
+      "II EXE 4Ptas. 2.0 N Trend (L08)",
+      "II EXE 4Ptas. 2.0 N Trend Plus (L08)",
+      "II EXE 4Ptas. 2.0 N Ghia (L08)",
+      "II EXE 4Ptas. 2.0 N Ghia AT (L08)",
+      "II EXE 4Ptas. 1.8 TD Style (L08)",
+      "II EXE 4Ptas. 1.8 TD Trend Plus (L08)",
+      "II EXE 4Ptas. 1.8 TD Ghia (L08)",
+      "II 5Ptas. 1.6 Sigma Style",
+      "II 5Ptas. 1.6 Sigma Trend",
+      "II 5Ptas. 2.0 N Trend (L08)",
+      "II 5Ptas. 2.0 N Trend Plus (L08)",
+      "II 5Ptas. 2.0 N Ghia (L08)",
+      "II 5Ptas. 2.0 N Ghia AT/Seq. (L08)",
+      "II 5Ptas. 1.8 TDCI Style (L08)",
+      "II 5Ptas. 1.8 TDCI Trend Plus (L08)",
+      "II 5Ptas. 1.8 TDCI Ghia (L08)",
+      "4Ptas. Ambiente 1.6 MP3",
+      "4Ptas. Edge 1.6 MP3",
+      "5Ptas. Edge 1.6 MP3",
+      "5Ptas. Ambiente 1.6 MP3"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 171,
+    "modelo": "Focus III",
+    "versiones": [
+      "1.6 S MT (125cv) 4Ptas. (L15)",
+      "2.0 SE MT (170cv) 4Ptas. (L15)",
+      "2.0 SE AT (170cv) 4Ptas. (L15)",
+      "2.0 SE Plus MT (170cv) 4Ptas. (L15)",
+      "2.0 SE Plus AT (170cv) 4Ptas. (L15)",
+      "2.0 Titanium MT (170cv) 4Ptas. (L15)",
+      "2.0 Titanium AT (170cv) 4Ptas. (L15)",
+      "1.6 S MT (125cv) 5Ptas. (L15)",
+      "2.0 SE MT (170cv) 5Ptas. (L15)",
+      "2.0 SE Plus MT (170cv) 5Ptas. (L15)",
+      "2.0 SE AT (170cv) 5Ptas. (L15)",
+      "2.0 SE Plus AT (170cv) 5Ptas. (L15)",
+      "2.0 Titanium MT (170cv) 5Ptas. (L15)",
+      "2.0 Titanium AT (170cv) 5Ptas. (L15)",
+      "1.6 S MT (125cv) 4Ptas.",
+      "2.0 SE MT (170cv) 4Ptas.",
+      "2.0 SE Plus MT (170cv) 4Ptas.",
+      "2.0 SE Plus AT (170cv) 4Ptas.",
+      "2.0 Titanium MT (170cv) 4Ptas.",
+      "2.0 Titanium AT (170cv) 4Ptas.",
+      "1.6 S MT (125cv) 5Ptas.",
+      "2.0 SE MT (170cv) 5Ptas.",
+      "2.0 SE Plus MT (170cv) 5Ptas.",
+      "2.0 SE Plus AT (170cv) 5Ptas.",
+      "2.0 Titanium MT (170cv) 5Ptas.",
+      "2.0 Titanium AT (170cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 172,
+    "modelo": "KA",
+    "versiones": [
+      "1.5 S MT (123cv) 4Ptas. (L18)",
+      "1.5 SE MT (123cv) 4Ptas. (L18)",
+      "1.5 SE AT (123cv) 4Ptas. (L18)",
+      "1.5 SEL MT (123cv) 4Ptas. (L18)",
+      "1.5 SEL AT (123cv) 4Ptas. (L18)",
+      "1.5 S MT (123v) 5Ptas. (L18)",
+      "1.5 SE MT (123cv) 5Ptas. (L18)",
+      "1.5 SE AT (123cv) 5Ptas. (L18)",
+      "1.5 SEL MT (123cv) 5Ptas. (L18)",
+      "1.5 SEL AT (123cv) 5Ptas. (L18)",
+      "1.5 SE Freestyle MT (123cv) 5Ptas. (L18)",
+      "1.5 SEL Freestyle MT (123cv) 5Ptas. (L18)",
+      "1.5 SEL Freestyle AT (123cv) 5Ptas. (L18)",
+      "1.5 S (105cv) 4Ptas.",
+      "1.5 SE (105cv) 4Ptas.",
+      "1.5 SEL (105cv) 4Ptas.",
+      "1.5 S (105cv) 5Ptas.",
+      "1.5 SE (105cv) 5Ptas.",
+      "1.5 SEL (105cv) 5Ptas.",
+      "1.0 Fly (L/08)",
+      "1.0 Fly Viral (L/08)",
+      "1.0 Fly Plus (L/08)",
+      "1.6 Fly Viral (L/08)",
+      "1.6 Pulse (L/08)",
+      "1.6 Top Pulse (L/08)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 173,
+    "modelo": "Kuga",
+    "versiones": [
+      "Hybrid eCVT 2WD SE (2.5/e) (165cv-130cv/203cv) (L20)",
+      "Hybrid eCVT 2WD Platinum (2.5/e) (165cv-130cv/203cv) (L23)",
+      "Hybrid eCVT 2WD Titanium (2.5/e) (165cv-130cv/203cv) (L20)",
+      "1.6T SEL 6MT FWD (150cv)",
+      "1.6t SEL 6AT AWD (182cv)",
+      "1.6t Titanium AT AWD (182cv)",
+      "2.0 SEL 6Sec. FWD (240cv) (L17)",
+      "2.0 SEL 6Sec. AWD (240cv) (L17)",
+      "2.0 GTdi Titanium 6Sec. AWD (240cv) (L17)",
+      "2.0 GTdi Titanium Sec. AWD (240cv)",
+      "2.5T MT Trend 4x4 (200cv)",
+      "2.5T AT Titanium 4x4 (200cv)",
+      "2.5T AT Titanium L 4x4 Cuero (200cv)",
+      "2.5T AT Titanium L 4x4 Cuero/Asiento eléct. (200cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 174,
+    "modelo": "Maverick",
+    "versiones": [
+      "XLT 2.0 Ecoboost AT8 AWD (253cv)",
+      "Tremor 2.0 Ecoboost AT8 4WD (253cv)",
+      "Lariat 2.5 Hybrid CVT AWD HEV (194cv)",
+      "XLT 2.0 Ecoboost AT8 2WD (253cv) DISCONTINUO",
+      "Lariat 2.0 Ecoboost AT8 4WD (253cv)",
+      "Lariat 2.0 Ecoboost FX4 AT8 4WD (253cv) DISCONTINUO",
+      "Lariat 2.5 Hybrid CVT 2WD FHEV (194cv) DISCONTINUO"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 175,
+    "modelo": "Mondeo",
+    "versiones": [
+      "2.0h eCVT Titanium (140cv/L4)",
+      "2.0h eCVT Vignale (140cv/L4)",
+      "2.0 Ecoboost GTDI SEL (240cv) (L17)",
+      "2.0 Ecoboost GTDI Titanium (240cv) (L17)",
+      "2.5 SE AT (175cv) (L15)",
+      "2.0 Ecoboost SE AT (240cv) (L15)",
+      "2.0 Ecoboost Titanium AT (240cv) (L15)",
+      "2.3 Duratec Ghia AT 4Ptas. (161cv) (L11)",
+      "2.3 Duratec Titanium AT 4Ptas. (161cv) L11)",
+      "2.0 GTDi Ecoboost Titanium AT 4Ptas. (240cv) (L11)",
+      "2.0 Tdci Ghia MT / AT 4Ptas. (140cv)",
+      "2.0 Tdci Titanium AT 4Ptas. (140cv) (L11)",
+      "2.0 N MT Ghia (L07)",
+      "2.3 N AT Ghia (L07)",
+      "2.3 N AT Titanium (L07)",
+      "2.5 N MT Titanium (L07)",
+      "1.8 TDCi MT Ghia (L07)",
+      "1.8 TDCi MT Titanium (L07)",
+      "2.0 TDCi MT Guia (L07)",
+      "2.0 TDCi MT Titanium (L07)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 176,
+    "modelo": "Mustang",
+    "versiones": [
+      "Mach 1 (480cv)",
+      "GT 5.0 Performance (488cv)",
+      "GT 5.0L 10AT (466cv)",
+      "GT 5.0L 6MT (421cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 177,
+    "modelo": "Mustang Mach-E",
+    "versiones": [
+      "GT Performance CVT eAWD (487cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 178,
+    "modelo": "Ranger",
+    "versiones": [
+      "2.3 Nafta C/S 4x2 F-Truck (148cv) (L09)",
+      "2.3 Nafta C/D 4x2 XL Plus (148cv) (L09)",
+      "3.0 TDI C/S 4x2 F-Truck (163cv) (L09)",
+      "3.0 TDI C/S 4x2 XL Plus (163cv) (L09)",
+      "3.0 TDI C/S 4x4 XL Plus (163cv) (L09)",
+      "3.0 TDI C/D 4x2 XL Base MP3 (163cv) (L09)",
+      "3.0 TDI C/D 4x2 XL Plus \\ MP3 (163cv) (L09)",
+      "3.0 TDI C/D 4x2 XLS MP3 (163cv) (L09)",
+      "3.0 TDI C/D 4X2 XLT (163cv) (L09)",
+      "3.0 TDI C/D 4x4 XL Plus MP3 (163cv) (L09)",
+      "3.0 TDI C/D 4x4 XLT (163cv) (L09)",
+      "3.0 TDI C/D 4x4 Super Duty (163cv) (L09)",
+      "3.0 TDI C/D 4x4 Limited (163cv) (L09)",
+      "2.0T XL 4x2 MT (170cv) (L23)",
+      "2.0T XL 4x4 MT (170cv) (L23)",
+      "2.0T XLS 4x2 MT (170cv) (L23)",
+      "2.0T Black 4x4 MT (170cv) (L23)",
+      "2.0BT XLT 4x2 AT (210cv) (L23)",
+      "2.0BT XLT 4x4 AT (210cv) (L23)",
+      "2.0BT Limited 4x4 AT (210cv) (L23)",
+      "3.0 V6 XLS 4x4 AT (250cv) (L23)",
+      "3.0 V6 Limited Plus 4x4 AT (250cv) (L23)",
+      "Raptor 3.0 Biturbo 4x4 AT10 (397cv)",
+      "2.5 N C/Simple 4x2 XL 5MT (166cv) (L20)",
+      "2.5 N C/Doble 4x2 XL 6MT (166cv) (L20)",
+      "2.5 N C/Doble 4x2 XLT 6MT (166cv) (L20)",
+      "2.2 TDCi C/Simple 4x2 XL 6MT (125cv) (L20)",
+      "2.2 TDCi C/Simple 4x4 XL 6MT (125cv) (L20)",
+      "2.2 TDCi C/Doble 4x2 XL 6MT (125cv) (L20)",
+      "2.2 TDCi C/Doble 4x4 XL 6MT (125cv) (L20)",
+      "2.2 TDCi C/Doble 4x2 XLT 6AT (125cv) (L20)",
+      "3.2 TDCi C/Doble 4x2 XLS 6MT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x2 XLS 6AT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x2 XLT 6MT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x2 XLT 6AT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 XLS 6MT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 XLT 6MT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 XLT 6AT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 FX4 6AT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 Limited 6MT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 Limited 6AT (200cv) (L20)",
+      "3.2 TDCi C/Doble 4x4 Black Edition 6AT (200cv) (L20)",
+      "Raptor 2.0 Biturbo 4x4 AT (213cv)",
+      "2.5 N C/Simple 5MT 4x2 XL (L12)",
+      "2.5 N C/Doble 5MT 4x2 XL (L12)",
+      "2.2 TDCi C/Simple 6MT 4x2 XL Safety (L12)",
+      "2.2 TDCi C/Simple 6MT 4x4 XL Safety (L12)",
+      "2.2 TDCi C/Doble 6MT 4x2 XL (L12)",
+      "2.2 TDCi C/Doble 6MT 4x2 XL Safety (L12)",
+      "2.2 TDCi C/Doble 6MT 4x4 XL Safety (L12)",
+      "3.2 TDCi C/Doble 6MT 4x2 XLS (L12)",
+      "3.2 TDCi C/Doble 6MT 4x2 XLS AT (L12)",
+      "3.2 TDCi C/Doble 6MT 4x2 XLT (L12)",
+      "3.2 TDCi C/Doble 6MT 4x2 XLT AT (L12)",
+      "3.2 TDCi C/Doble 6MT 4x4 XLS (L12)",
+      "3.2 TDCi C/Doble 6MT 4x4 XLT (L12)",
+      "3.2 TDCi C/Doble 6MT 4x4 XLT AT (L12)",
+      "3.2 TDCi C/Doble 6MT 4x4 LTD (L12)",
+      "3.2 TDCi C/Doble 6AT 4x4 LTD (L12)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 179,
+    "modelo": "S-Max",
+    "versiones": [
+      "Trend 1.8 TDCi (125cv)",
+      "Trend 2.0 N",
+      "Titanium 2.3 N (161cv)",
+      "Trend 2.0 Ecoboost (240cv) (L17)",
+      "Titanium 2.0 Ecoboost (240cv) (L17)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 180,
+    "modelo": "Territory",
+    "versiones": [
+      "1.8T AT7 SEL (185cv)",
+      "1.8T AT7 Titanium (185cv)",
+      "1.5T CVT SEL (143cv)",
+      "1.5T CVT Titanium (143cv)"
+    ]
+  },
+  {
+    "marca": "FORD",
+    "modeloId": 181,
+    "modelo": "Transit",
+    "versiones": [
+      "E- Chasis Cabina AT (BEV) (269cv)",
+      "E- Furgon Mediano TN AT (BEV) (269cv)",
+      "E- Furgon Mediano TE AT (BEV) (269cv)",
+      "E- Furgon Largo TE AT (BEV) (269cv)",
+      "2.2 TD Furgón Medio (125cv) (L23)",
+      "2.2 TD Furgón Medio TE (125cv) (L23)",
+      "2.2 TD Furgón Largo TE (125cv) (L23)",
+      "2.0 TD Chasis (165cv) (L23)",
+      "2.0 TD Furgón Largo AT10 TE (165cv) (L23)",
+      "2.0 TD Minibus (165cv) (L23)",
+      "2.0 TD Minibus AT10 (165cv) (L23)",
+      "2.2 TD Chasis AA (L14)",
+      "2.2 TD Furgón Medio AA (L14)",
+      "2.2 TD Furgón Medio TE AA (L14)",
+      "2.2 TD Furgón Largo AA (L14)",
+      "2.2 TD Furgón Largo TE AA (L14)",
+      "2.2 TD Minibus AA (L14)",
+      "2.2 / 2.4 TD Furgon Corto TM ABG ABS (125cv/115cv) (L11)",
+      "2.2 / 2.4 TD Furgon Corto TM  ABG ABS AA (125cv/115cv) (L11)",
+      "2.2 / 2.4 TD Furgon Largo TA  ABG ABS (125cv/115cv) (L11)",
+      "2.2 / 2.4 TD Furgon Largo TA  ABG ABS AA (125cv/115cv) (L11)",
+      "2.2 / 2.4 TD Minibus 13+1 TM ABG ABS AA (125cv/115cv) (L11)",
+      "2.2 TD Chasis Cabina (125cv)",
+      "2.2 TD Chasis Cabina AA (125cv)"
+    ]
+  },
+  {
+    "marca": "FOTON",
+    "modeloId": 709,
+    "modelo": "Auman",
+    "versiones": null
+  },
+  {
+    "marca": "FOTON",
+    "modeloId": 710,
+    "modelo": "Aumark",
+    "versiones": null
+  },
+  {
+    "marca": "FOTON",
+    "modeloId": 182,
+    "modelo": "Gratour",
+    "versiones": [
+      "T3 1.2 16v. Cabina Simple (86cv)",
+      "T3 1.2 16v. Cabina Doble (86cv)"
+    ]
+  },
+  {
+    "marca": "FOTON",
+    "modeloId": 183,
+    "modelo": "Tunland",
+    "versiones": [
+      "2.8 MT 4x2 Cab/doble (170cv)",
+      "2.8 MT 4x4 Standard Cab/doble (170cv)",
+      "2.8 MT 4x4 Luxury Cab/doble (170cv)"
+    ]
+  },
+  {
+    "marca": "FOTON",
+    "modeloId": 184,
+    "modelo": "View",
+    "versiones": [
+      "CS2 Microbus 15as."
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 185,
+    "modelo": "515",
+    "versiones": [
+      "GS 1.5 (110hp) 4Ptas.",
+      "GL 1.5 (110hp) 4Ptas.",
+      "GS 1.5 (110hp) 5Ptas.",
+      "GL 1.5 (110hp) 5Ptas."
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 188,
+    "modelo": "Emgrand Fe 3",
+    "versiones": [
+      "Drive 1.8 5MT (140cv) (L19) 4Ptas.",
+      "Active 1.8 CVT (140cv) (L19) 4Ptas.",
+      "GS 1.8 5MT (140cv) 4Ptas.",
+      "GL 1.8 5MT (140cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 189,
+    "modelo": "Emgrand GS",
+    "versiones": [
+      "Drive 1.8 6MT (GS) (140hp)",
+      "Drive Plus 1.8 6MT (GS) (140hp)",
+      "Balance 1.8 6MT (GL) (140hp)",
+      "Balance 1.8 6AT (GL) (140hp)",
+      "Active 1.8 6MT (140hp)",
+      "Executive 1.8 6MT (GSP) (140hp)",
+      "Executive 1.8 6AT (GSP) (140hp)"
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 190,
+    "modelo": "Emgrand X7 Sport",
+    "versiones": [
+      "Drive 2.0 6MT (GS) (141hp)",
+      "Active 2.4 6AT (GL) (162hp)",
+      "Executive 2.4 6AT 4WD (GT) (162hp)"
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 186,
+    "modelo": "LC",
+    "versiones": [
+      "GB 1.3 (85hp)",
+      "GL 1.3 (85hp)"
+    ]
+  },
+  {
+    "marca": "GEELY",
+    "modeloId": 187,
+    "modelo": "LC Cross",
+    "versiones": [
+      "GL 1.3 (85hp)"
+    ]
+  },
+  {
+    "marca": "GREAT WALL",
+    "modeloId": 1487,
+    "modelo": "Ora",
+    "versiones": [
+      "03 E (170cv)"
+    ]
+  },
+  {
+    "marca": "GREAT WALL",
+    "modeloId": 191,
+    "modelo": "Poer",
+    "versiones": [
+      "2.0 TDI Super Luxury AT8 4WD (163cv)",
+      "Elite 2.0 TDI MT6 2WD (163cv)",
+      "Elite 2.0 TDI MT6 4WD (163cv)"
+    ]
+  },
+  {
+    "marca": "GREAT WALL",
+    "modeloId": 192,
+    "modelo": "Wingle 5",
+    "versiones": [
+      "2.0 TD C/Simple 4x2 6MT Standard (137cv)",
+      "2.0 TD C/Doble 4x2 6MT Standard (137cv)",
+      "2.0 TD C/Doble 4x2 6MT Luxe (137cv)",
+      "2.0 TD C/Doble 4x4 6MT Standard (137cv)"
+    ]
+  },
+  {
+    "marca": "GREAT WALL",
+    "modeloId": 193,
+    "modelo": "Wingle 6",
+    "versiones": [
+      "2.0 TD C/Doble 4x4 6MT Dignity (137cv)"
+    ]
+  },
+  {
+    "marca": "GREAT WALL",
+    "modeloId": 194,
+    "modelo": "Wingle 7",
+    "versiones": [
+      "2.0 TD C/Doble 4x2 6MT Standard (137cv)",
+      "2.0 TD C/Doble 4x4 6MT Luxury (137cv)"
+    ]
+  },
+  {
+    "marca": "HAVAL",
+    "modeloId": 195,
+    "modelo": "H1",
+    "versiones": [
+      "1.5 Comfort MT (106cv)",
+      "1.5 Luxury MT (106cv)",
+      "1.5 Elite MT (106cv)"
+    ]
+  },
+  {
+    "marca": "HAVAL",
+    "modeloId": 196,
+    "modelo": "H2",
+    "versiones": [
+      "1.5T Comfort MT (141cv)",
+      "1.5T Luxury AT (141cv)"
+    ]
+  },
+  {
+    "marca": "HAVAL",
+    "modeloId": 197,
+    "modelo": "H6",
+    "versiones": [
+      "1.5T AT 2WD HEV (150-177/243cv)",
+      "2.0T AT7 GT (201cv)",
+      "2.0T Dignity 7AT 2WD (190cv) (L23)",
+      "2.0T Dignity 7AT 4WD (190cv) (L23)",
+      "2.0T Dignity 7AT (190cv) (L21)"
+    ]
+  },
+  {
+    "marca": "HAVAL",
+    "modeloId": 198,
+    "modelo": "Jolion",
+    "versiones": [
+      "1.5T AT7 2WD Deluxe (141cv)",
+      "1.5T AT7 2WD Supreme (141cv)",
+      "1.5 AT 2WD Pro Deluxe Hybrid (94-54/188cv)",
+      "1.5 AT 2WD Pro Supreme Hybrid (94-54/188cv)"
+    ]
+  },
+  {
+    "marca": "HEIBAO",
+    "modeloId": 199,
+    "modelo": "HB",
+    "versiones": [
+      "1605 Pick up",
+      "1605 Full 4x4"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 200,
+    "modelo": "Accord",
+    "versiones": [
+      "2.0 AT Advanced Hybrid HEV (145cv-184cv)",
+      "2.0T EXT AT (250cv) (L18)",
+      "2.4 EXL MT (182cv) (L08)",
+      "2.4 EXL AT (175cv) (L13)",
+      "2.4 EXL AT (182cv) (L08)",
+      "3.5 EXL V6 (280cv) (L16)",
+      "3.5 EX V6 (L13)",
+      "3.5 EX V6 (273hp) (L08)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 798,
+    "modelo": "ATV",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 794,
+    "modelo": "Business",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 201,
+    "modelo": "City",
+    "versiones": [
+      "1.5 LX MT 2ABG (120cv)",
+      "1.5 EXL MT 2ABG ABS Cuero (120cv)",
+      "1.5 EXL AT  2ABG ABS Cuero (120cv)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 202,
+    "modelo": "Civic",
+    "versiones": [
+      "2.0 Advanced Hybrid HEV (143cv) (L24)",
+      "1.8 LXS MT Sedán (140cv) (L12)",
+      "1.8 LXS MT Sedán (140cv) (L06)",
+      "1.8 LXS AT Sedán (140cv) (L12)",
+      "1.8 LXS AT Sedán (140cv) (L06)",
+      "1.8 EXS MT Sedán (140cv) (L12)",
+      "1.8 EXS MT Sedán (140cv) (L06)",
+      "1.8 EXS AT Sedán (140cv) (L12)",
+      "1.8 EXS AT Sedán (140cv) (L06)",
+      "2.0 Si 6MT Sedán (200cv) (L06)",
+      "2.0 EX CVT Sedán (154cv) (L17)",
+      "2.0 EX-L CVT PaddleShift 7 Sedán (154cv) (L17)",
+      "1.5T EXT CVT Sedán (173cv) (L17)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 203,
+    "modelo": "CRV",
+    "versiones": [
+      "Advanced Hybrid 4WD HEV (143/184e)",
+      "1.5 iVtec LX CVT 2WD (190cv) (L24)",
+      "1.5 iVtec EX CVT 2WD (190cv) (L24)",
+      "1.5 iVtec EXL CVT AWD (190cv) (L24)",
+      "2.4 LX CVT 2WD (186cv) (L20)",
+      "1.5 iVtec EX CVT 2WD (190cv) (L20)",
+      "1.5 iVtec EXT CVT AWD (190cv) (L20)",
+      "1.5 iVtec EXT CVT AWD (190cv) (L18)",
+      "2.4 LX AT 4x2 (185cv) (L12)",
+      "2.4 EX AT 4x4 (185cv) (L12)",
+      "2.4 EXL AT 4x4 (185cv) (L12)",
+      "2.4 LX AT 4x2 (170cv) (L07)",
+      "2.4 LX AT 4x4 (170cv) (L07)",
+      "2.4 EX AT 4x4 (170cv) (L07)",
+      "2.4 EXL AT 4x4 (170cv) (L07)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 204,
+    "modelo": "Fit",
+    "versiones": [
+      "1.4 LX MT IVTEC (L09)",
+      "1.4 LX AT IVTEC (L09)",
+      "1.4 LXL MT IVTEC (L09)",
+      "1.4 LXL AT IVTEC (L09)",
+      "1.5 EX MT IVTEC (L09)",
+      "1.5 EX CVT IVTEC (120cv) (L18)",
+      "1.5 EXL CVT IVTEC (120cv) (L18)",
+      "1.5 EXL CVT IVTEC (132cv) (L17)",
+      "1.5 EXL AT IVTEC (L09)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 205,
+    "modelo": "HR-V",
+    "versiones": [
+      "1.5 LX CVT 2WD (121cv) (L23)",
+      "1.5 EXL CVT 2WD (121cv) (L23)",
+      "1.8 i-VTEC LX CVT 2WD (140cv) (L21)",
+      "1.8 i-VTEC EX CVT 2WD (140cv) (L21)",
+      "1.8 i-VTEC EX-L CVT 2WD (140cv) (L21)",
+      "1.8 i-VTEC LX CVT 2WD (140cv) (L20)",
+      "1.8 i-VTEC EX CVT 2WD (140cv) (L20)",
+      "1.8 i-VTEC EX-L CVT 2WD (140cv) (L20)",
+      "1.8  i-VTEC LX MT 2WD (140cv)",
+      "1.8 i-VTEC LX CVT 2WD (140cv)",
+      "1.8 i-VTEC EX CVT 2WD (140cv)",
+      "1.8 i-VTEC EX-L CVT 2WD (140cv)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 795,
+    "modelo": "On-Off",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 206,
+    "modelo": "Pilot",
+    "versiones": [
+      "3.5 V6  i-VTEC 24v EX 2WD (280cv)",
+      "3.5 V6 i-VTEC 24v TOURING AWD (280cv)",
+      "EX 4x4 3.5 V6 i-VTEC 24v (257cv)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 796,
+    "modelo": "Scooter",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 797,
+    "modelo": "Sport",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 799,
+    "modelo": "Touring",
+    "versiones": null
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 207,
+    "modelo": "WR-V",
+    "versiones": [
+      "1.5 CVT EX (120cv)",
+      "1.5 CVT EXL (120cv)"
+    ]
+  },
+  {
+    "marca": "HONDA",
+    "modeloId": 208,
+    "modelo": "ZR-V",
+    "versiones": [
+      "2.0 CVT LX (157cv) DISCONTINUO",
+      "2.0 CVT Touring (157cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 209,
+    "modelo": "Coupé",
+    "versiones": [
+      "Génesis 2.0 Turbo MT Full Seguridad (275cv)",
+      "Génesis 2.0 Turbo MT Full Seguridad (210cv)",
+      "Génesis 2.0 Turbo AT Full Seguridad (275cv)",
+      "Génesis 3.8 V6 MT Full Seguridad Premium (303cv)",
+      "Génesis 3.8 V6 AT Full Seguridad Premium (303cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 210,
+    "modelo": "Creta",
+    "versiones": [
+      "1.5 CVT Safety (115cv)",
+      "1.5 CVT Safety+ (115cv)",
+      "1.6 Style AT (123cv)",
+      "1.6 Safety AT (123cv)",
+      "1.6 Safety+ AT (123cv)",
+      "1.6 GL Connect MT (123cv)",
+      "1.6 GL Connect AT (123cv)",
+      "1.6 GL MT (123cv)",
+      "1.6 GL AT (123cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 211,
+    "modelo": "Elantra",
+    "versiones": [
+      "1.8 GLS 6MT Full Seguridad Premium 4Ptas. (150cv) (L13)",
+      "1.8 GLS 6AT Full Seguridad Premium 4Ptas. (150cv) (L13)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 212,
+    "modelo": "Grand i10",
+    "versiones": [
+      "1.2 GLS MT Full Seguridad 4Ptas.",
+      "1.2 GLS AT Full Seguridad 4Ptas.",
+      "1.2 GLS MT Full Seguridad 5Ptas.",
+      "1.2 GLS AT Full Seguridad 5Ptas."
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 218,
+    "modelo": "Grand Santa Fe",
+    "versiones": [
+      "2.2 CRDI 4WD GLS 7P 6AT Full Premium",
+      "2.2 CRDI 4WD GLS 7P 6AT Full Premium Nav.",
+      "2.2 CRDI 4WD GLS 7P 6AT GPS",
+      "3.3 N 4WD GLS 7P 6AT GPS",
+      "3.3 N 4WD GLS 7P 6AT GPS Full Premium"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 713,
+    "modelo": "H 100",
+    "versiones": null
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 714,
+    "modelo": "H 350",
+    "versiones": null
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 223,
+    "modelo": "H1",
+    "versiones": [
+      "Minibus 12 Pas. 2.5 TDI MT Full Plus (L08)",
+      "Minibus 12 Pas. 2.5 TDI MT Full Premium (L08)",
+      "Minibus 12 Pas. 2.5 TDI AT Full Premium (L08)",
+      "Minibus 12 Pas. 2.4 Nafta 4AT Full Premium (136cv) (L15)",
+      "Minibus 12 Pas. 2.5 CRDI MT Full WGT (136cv) (L12)",
+      "Minibus 12 Pas. 2.5 CRDI MT Full Premium WGT (136 cv) (L16)",
+      "Minibus 12 Pas. 2.5 CRDI MT Full Premium WGT (136cv) (L12)",
+      "Minibus 12 Pas. 2.5 CRDI AT Full Premium VGT (170cv) (L16)",
+      "Minibus 12 Pas. 2.5 CRDI AT Full Premium VGT (170cv) (L12)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 692,
+    "modelo": "HB20",
+    "versiones": [
+      "1.6 MT6 Comfort Plus (126cv) 4Ptas.",
+      "1.6 AT6 Platinum (126cv) 4Ptas.",
+      "1.6 MT6 Comfort Plus (126cv) 5Ptas.",
+      "1.6 AT6 Comfort Plus (126cv) 5Ptas.",
+      "1.6 AT6 Platinum Safety (126cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 715,
+    "modelo": "HD65",
+    "versiones": null
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 716,
+    "modelo": "HD78",
+    "versiones": null
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 213,
+    "modelo": "i10",
+    "versiones": [
+      "1.2 GLS MT",
+      "1.2 GLS AT"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 214,
+    "modelo": "i30",
+    "versiones": [
+      "1.4 MT GLS Full Seguridad (109cv)",
+      "1.6 MT GLS Full Seguridad (122cv)",
+      "1.6 MT GLS Full Seguridad Premium (122cv)",
+      "1.6 AT GLS Full Seguridad (122cv)",
+      "1.6 AT GLS Full Seguridad Premium (122cv)",
+      "1.8 MT GLS Full Seguridad (150cv)",
+      "1.8 MT GLS Full Seguridad Premium (150cv)",
+      "1.8 AT GLS Full Seguridad (150cv)",
+      "1.8 AT GLS Full Seguridad Premium (150cv)",
+      "2.0 MT GLS Full Seguridad Premium (143cv)",
+      "2.0 AT GLS Full Seguridad Premium (143cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 215,
+    "modelo": "Ioniq",
+    "versiones": [
+      "Hybrid 1.6N (105cv) Elec. (43.5cv) 6AT"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 216,
+    "modelo": "Kona",
+    "versiones": [
+      "1.6T 7AT Style 2WD (177cv)",
+      "1.6T 7AT Safety+ 2WD (177cv)",
+      "1.6T 7AT Safety+ 4WD (177cv)",
+      "1.6T 7AT Ultimate 4WD (177cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 217,
+    "modelo": "Santa Fe",
+    "versiones": [
+      "2.4 2WD 6MT GL 7Pas. (172cv) (L16)",
+      "2.4 2WD 6AT GL 7Pas. (172cv) (L16)",
+      "2.4 4WD 6AT GLS Premium 5Pas. (172cv) (L16)",
+      "2.4 4WD 6AT GLS Premium 7Pas. (172cv) (L16)",
+      "2.2 CRDI 4WD 6AT GLS Premium 7Pas. (200cv) (L16)",
+      "2.2 CRDI 4WD 6AT GLS Premium CHAPELCO 7Pas. (200cv) (L16)",
+      "2.4 2WD 6MT GL Full 7Pas. (176cv) (L13)",
+      "2.4 2WD 6AT GL Full 7Pas. (176cv) (L13)",
+      "2.4 4WD 6AT GLS Premium 5Pas. (176cv) (L13)",
+      "2.4 4WD 6AT GLS Premium 7Pas. (176cv) (L13)",
+      "2.2 CRDi 4WD 6AT GLS Premium 7Pas. (L13)",
+      "2.4 2WD 6MT GLS 7Pas. (L10)",
+      "2.4 4WD 6MT GLS Full 7Pas. (L10)",
+      "2.4 4WD 6AT GLS Premium 5Pas. (L10)",
+      "2.4 4WD 6AT GLS Premium 7Pas. (L10)",
+      "2.2 CRDi 4WD 6MT GLS Premium 5Pas. (L10)",
+      "2.2 CRDi 4WD 6MT GLS Full 7Pas.(L10)",
+      "2.2 CRDi 4WD 6MT GLS Premium 7Pas. (L10)",
+      "2.7 V6 MT GLS Premium 5Pas. (L06)",
+      "2.7 V6 AT GLS Premium 5Pas. (L06)",
+      "2.7 V6 MT GLS Full 7Pas. (L06)",
+      "2.7 V6 AT GLS Premium 7Pas. (L06)",
+      "2.2 CRDi MT GLS Premium 5Pas. (150cv) (L06)",
+      "2.2 CRDi AT GLS Premium 5Pas. (150cv) (L06)",
+      "2.2 CRDi MT GLS Full 7Pas. (150cv) (L06)",
+      "2.2 CRDi MT GLS Premium 7Pas. (150cv) (L06)",
+      "2.2 CRDi AT GLS Premium 7Pas. (150cv) (L06)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 219,
+    "modelo": "Staria",
+    "versiones": [
+      "2.2TD AT8 Safety 2WD (177cv)",
+      "2.2TD AT8 4WD 11Pas. (177cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 220,
+    "modelo": "Tucson",
+    "versiones": [
+      "2.0 2WD AT6 Safety (156cv) (L24)",
+      "1.6T 4WD 7AT Ultimate (180cv) (L24)",
+      "2.0 2WD MT Style (155cv) (L19)",
+      "2.0 2WD AT Style (155cv) (L19)",
+      "2.0 2WD AT Panorama Sunroof (155cv) (L19)",
+      "2.0 4WD AT Full Premium (155cv) (L19)",
+      "1.6T 4WD 7AT Full Premium (177cv) (L19)",
+      "2.0D 4WD 8AT Full Premium (185cv) (L19)",
+      "2.0 N GL MT 2WD (155cv) (L16)",
+      "2.0 N GL AT 2WD (155cv) (L16)",
+      "2.0 N GLS AT 4WD Full C/Techo (155cv) (L16)",
+      "2.0 N GLS AT 4WD Full Premium (155cv) (L16)",
+      "2.0 D GLS AT 4WD Full Premium (185cv) (L16)",
+      "2.0 N GL 5MT 2WD (166cv) (L10)",
+      "2.0 N GL 6AT 2WD (166cv) (L10)",
+      "2.0 N GLS 5MT 4WD Full (166cv) (L10)",
+      "2.0 N GLS 6AT 4WD Full (166cv) (L10)",
+      "2.0 N GLS 6AT 4WD Full Premium (166cv) (L10)",
+      "2.0 D GLS 6MT 4WD Full (184cv) (L10)",
+      "2.0 D GLS 6AT 4WD Full (184cv) (L10)",
+      "2.0 N MT 2WD CWT (L05)",
+      "2.0 N MT 4WD CWT (L05)",
+      "2.0 CRDi AT 2WD (L05)",
+      "2.0 CRDI MT 4WD (L05)",
+      "2.0 CRDI AT 4WD (L05)",
+      "2.7 N AT V6 4WD 6ABG (L05)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 221,
+    "modelo": "Veloster",
+    "versiones": [
+      "Tech 2.0 AT (150cv)",
+      "Sport 1.6T MT (204cv)",
+      "Ultimate 1.6T 7DCT (204cv)",
+      "N 2.0T MT (250cv)",
+      "1.6 16v MPI 6MT (130cv)",
+      "1.6 16v MPI 6AT (130cv)"
+    ]
+  },
+  {
+    "marca": "HYUNDAI",
+    "modeloId": 222,
+    "modelo": "Veracruz",
+    "versiones": [
+      "GLS 3.8 N AT V6 7pas Full Premium",
+      "GLS 3.0 CRDI AT V6 7pas Full Premium"
+    ]
+  },
+  {
+    "marca": "ISUZU",
+    "modeloId": 224,
+    "modelo": "D-Max Kenzu",
+    "versiones": [
+      "DC 4X4 6MT RBD",
+      "DC 4X4 6AT RBD"
+    ]
+  },
+  {
+    "marca": "ISUZU",
+    "modeloId": 717,
+    "modelo": "NPR 75 (Camión)",
+    "versiones": null
+  },
+  {
+    "marca": "ISUZU",
+    "modeloId": 718,
+    "modelo": "NQR90",
+    "versiones": null
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 693,
+    "modelo": "JS4",
+    "versiones": [
+      "1.5T CVT (147cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 1484,
+    "modelo": "JS8 PRO",
+    "versiones": [
+      "1.5T AT7 (182cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 225,
+    "modelo": "S2",
+    "versiones": [
+      "1.5 MT Luxury (113cv) 5Ptas.",
+      "1.5 MT Intelligent FL (105cv) 5Ptas.",
+      "1.5 MT Intelligent (113cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 226,
+    "modelo": "S3",
+    "versiones": [
+      "1.6 MT Intelligent FL (109cv) 5Ptas.",
+      "1.6 MT Intelligent (118cv) 5Ptas.",
+      "1.6 CVT Intelligent FL (109cv) 5Ptas.",
+      "1.6 CVT Intelligent (118cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 227,
+    "modelo": "S5",
+    "versiones": [
+      "2.0T DCT Intelligent (163cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 228,
+    "modelo": "S7",
+    "versiones": [
+      "2.0 DCT Luxury (196cv)",
+      "2.0 DCT Intelligent (196cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 972,
+    "modelo": "S8",
+    "versiones": null
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 229,
+    "modelo": "T6",
+    "versiones": [
+      "C/Doble 2.0D 4x2  6MT Luxury (139cv)",
+      "C/Doble 2.0D 4x4 6MT Luxury (139cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 230,
+    "modelo": "T8",
+    "versiones": [
+      "2.0TD 4x4 MT Inteligent (139cv)"
+    ]
+  },
+  {
+    "marca": "JAC",
+    "modeloId": 231,
+    "modelo": "X200",
+    "versiones": [
+      "C/Simple 2.0D 6MT Luxury (136cv)",
+      "Cargo Box 2.0D 6MT Luxury (136cv)"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 234,
+    "modelo": "F-Pace",
+    "versiones": [
+      "2.0D Prestige",
+      "3.0 Prestige",
+      "3.0 R-Sport"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 235,
+    "modelo": "F-Type",
+    "versiones": [
+      "3.0 Cabrio",
+      "3.0 Coupé",
+      "R 5.0 S/C Cabrio"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 232,
+    "modelo": "XE",
+    "versiones": [
+      "2.0 Pure (240cv)",
+      "2.0 Prestige (240cv)",
+      "2.0 R Sport (240cv)",
+      "3.0 Prestige S (340cv)",
+      "2.0 SE (240cv)",
+      "2.0 R Sport (240cv) (L16)",
+      "2.0 S (240cv)"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 233,
+    "modelo": "XF",
+    "versiones": [
+      "2.0 Premium Lux. / Prestige",
+      "3.0 S",
+      "2.0T Luxury Premium",
+      "3.0 V6 (230cv)",
+      "R 5.0 S/C (510cv)"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 236,
+    "modelo": "XJ",
+    "versiones": [
+      "5.0 V8"
+    ]
+  },
+  {
+    "marca": "JAGUAR",
+    "modeloId": 237,
+    "modelo": "XK",
+    "versiones": [
+      "5.0 Coupé",
+      "R 5.0 S/C Coupé (510cv)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 238,
+    "modelo": "Cherokee",
+    "versiones": [
+      "Trailhawk 3.2 9AT 4x4 (271cv) (L17)",
+      "Limited 3.7 Nafta AT (L08)",
+      "Sport 2.8 TD CRD AT (L08)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 239,
+    "modelo": "Commander",
+    "versiones": [
+      "1.3T AT6 4x4 Limited (175cv)",
+      "2.0 AT9 4x4 Limited (170cv)",
+      "2.0 AT9 4x4 Overland (170cv)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 240,
+    "modelo": "Compass",
+    "versiones": [
+      "T270 1.3T Sport 6AT 4x2 (175cv)",
+      "T270 1.3T Longitud 6AT 4x2 (175cv)",
+      "T270 1.3T Longitud Plus 6AT 4x2 (175cv)",
+      "T270 1.3T Limited Plus 6AT 4x2 (175cv)",
+      "T270 1.3T Serie-S 6AT 4x2 (175cv)",
+      "2.0 TD Limited Plus AT9 4x4 (170cv) (L19)",
+      "TD350 2.0 Trailhawk AT9 4x4 (170cv) (L19)",
+      "2.4 Sport MT6 FWD (L19)",
+      "2.4 Sport AT6 FWD (L19)",
+      "2.4 Longitude AT6 FWD (L19)",
+      "2.4 Longitude Plus AT9 AWD (L19)",
+      "2.4 Limited Plus AT9 AWD (L19)",
+      "2.4 Sport MT6 FWD (174cv) (L17)",
+      "2.4 Sport AT6 FWD (L17)",
+      "2.4 Longitude AT6 FWD (174cv) (L17)",
+      "2.4 Longitude AT9 AWD (174cv) (L17)",
+      "2.4 Opening Edition AT9 AWD (174cv) (L17)",
+      "2.4 Limited AT9 AWD (174cv) (L17)",
+      "2.4 Limited Plus AT9 AWD (174cv) (L17)",
+      "Sport 2.4 Nafta Sec.",
+      "Limited 2.4 Nafta MT Techo",
+      "Limited 2.4 Nafta CVT Techo"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 241,
+    "modelo": "Gladiador",
+    "versiones": [
+      "Overland 3.6 8AT (258cv)",
+      "Rubicon 3.6 8AT (258cv)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 242,
+    "modelo": "Grand Cherokee",
+    "versiones": [
+      "Laredo 3.0 CRD V6 AT (218hp) (L06)",
+      "Limited 3.0 CRD V6 AT (218hp) (L06)",
+      "Limited 3.6 V6 8AT (293hp) (L23)",
+      "Limited 3.6 V6 8AT (286hp) (L13)",
+      "Limited 3.6 V6 AT (286hp) (L11)",
+      "Limited 4.7 SCV V8 AT (237hp) (L06)",
+      "Overland 3.6 V6 8AT (286hp) (L13)",
+      "Overland 3.6 V6 AT (286hp) (L11)",
+      "Overland 5.7 Hemi (326hp) (L06)",
+      "SRT8 6.1 AT (425hp) (L06)",
+      "SRT 6.4 8AT V8 Hemi (465hp)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 243,
+    "modelo": "Patriot",
+    "versiones": [
+      "Sport 2.0 MT 4x2 (158cv)",
+      "Sport 2.4 MT 4WD (172cv)",
+      "Sport 2.4 CVT 4WD (172cv)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 244,
+    "modelo": "Renegade",
+    "versiones": [
+      "1.8 MT Sport Wild (128cv)",
+      "1.8 MT Sport (130cv) (L23)",
+      "1.8 MT Sport (128cv) (L19)",
+      "1.8 MT Sport (128cv)",
+      "1.8 MT Sport Plus (128cv)",
+      "1.8 AT Sport (130cv) (L23)",
+      "1.8 AT Sport (128cv) (L19)",
+      "1.8 AT Sport (128cv)",
+      "1.8 AT Sport Plus (128cv)",
+      "1.3T AT6 Longitude T270 (175cv) (L23)",
+      "1.8 AT Longitude (128cv) (L19)",
+      "1.8 AT Longitude (128cv)",
+      "1.3T AT6 Serie-S T270 (175cv) (L23)",
+      "1.8 AT Anniversary (128cv) (L19)",
+      "2.4 AT Longitude 4x4 (138cv)",
+      "1.3T AT9 Trailhawk 4x4 T270 (175cv) (L23)",
+      "2.0D 9AT Trailhawk 4x4 (170cv) (L19)",
+      "2.0D 9AT Trailhawk 4x4 (170cv)",
+      "1.3T AT9 Willys 4x4 T270 (175cv) (L23)"
+    ]
+  },
+  {
+    "marca": "JEEP",
+    "modeloId": 245,
+    "modelo": "Wrangler",
+    "versiones": [
+      "Rubicon 3.6 AT8 (285cv) (L20) 2Ptas.",
+      "Rubicon 2.0T AT8 (272cv) (L25) 4Ptas.",
+      "Unlimited Sahara 3.6 AT8 4Ptas. (L20)",
+      "Unlimited Rubicon 3.6 AT8 4Ptas. (L20)",
+      "Sport 3.6 AT5 AWD HT 2Ptas. (L19)",
+      "Sport 3.6 AT5 AWD DT 2Ptas. (L19)",
+      "Sport 3.6 MTX 2Ptas. (284hp)",
+      "Sport 3.8 MT 2Ptas. (197hp)",
+      "Sport 3.6 ATX 2Ptas. (284hp)",
+      "Sport 3.8 AT 2Ptas.",
+      "Unlimited Sport 3.6 AT5 AWD HT 4Ptas. (L19)",
+      "Unlimited Sport 3.6 AT5 AWD DT 4Ptas.(L19)",
+      "Unlimited Sport 3.6 MTX 4Ptas. (284hp)",
+      "Unlimited Sport 3.8 MT 4Ptas. (197hp)",
+      "Unlimited Sport 3.6 ATX 4Ptas. (284hp)",
+      "Unlimited Sport 3.8 AT 4Ptas. (197hp)",
+      "Unlimited Mountain Sport 3.8 AT 4Ptas.",
+      "Rubicon 3.6 ATX 4Ptas. (284hp)"
+    ]
+  },
+  {
+    "marca": "JETOUR",
+    "modeloId": 694,
+    "modelo": "Dashing",
+    "versiones": [
+      "1.6T AT7 (197cv)"
+    ]
+  },
+  {
+    "marca": "JETOUR",
+    "modeloId": 246,
+    "modelo": "X70",
+    "versiones": [
+      "1.5T MT (147cv)",
+      "1.5T AT8 7as. (147cv)",
+      "1.6T Plus AT7 7as. (197cv)"
+    ]
+  },
+  {
+    "marca": "JMC",
+    "modeloId": 732,
+    "modelo": "Camión liviano",
+    "versiones": null
+  },
+  {
+    "marca": "JMC",
+    "modeloId": 973,
+    "modelo": "Gran Avenue",
+    "versiones": [
+      "2.3N GTDi 4x2 GL MT6 (242hp)",
+      "2.3N GTDi 4x4 SLX AT8 (242hp)",
+      "2.3N GTDi 4x4 DADAO PRO AT8 (242hp)",
+      "2.3TD 4x2 GL AT8 (174hp)",
+      "2.3TD 4x4 GL MT6 (174hp)",
+      "2.3TD 4x4 GL AT8 (174hp)"
+    ]
+  },
+  {
+    "marca": "KAIYI",
+    "modeloId": 1479,
+    "modelo": "X3",
+    "versiones": [
+      "1.5 CVT (116cv)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 247,
+    "modelo": "Carnival",
+    "versiones": [
+      "2.2 TD EX 8AT (199cv) (L22)",
+      "2.2 TD SX 8AT Premium (199cv) (L22)",
+      "2.2 TD 8AT Full (197cv) (L19)",
+      "2.2 TD 8AT Premium (197cv) (L19)",
+      "2.2 TD 8AT Premium TC (197cv) (L19)",
+      "2.2 TD 6AT Full (197cv) (L16)",
+      "2.2 TD 6AT Premium (197cv) (L16)",
+      "2.7 N AT Full Corta",
+      "2.9 CRDi EX STD AT Corta (160hp)",
+      "2.9 CRDi EX Full AT Corta (160hp)",
+      "2.9 CRDi EX Full AT Larga (160hp)",
+      "3.8 V6 EX Full AT Larga (245hp)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 248,
+    "modelo": "Cerato",
+    "versiones": [
+      "1.6T GT Turbo AT7 4Ptas. (201cv) (L20)",
+      "2.0 SX 6AT 4Ptas. (152cv) (L20)",
+      "2.0 SX Plus 6AT 4Ptas. (152cv) (L20)",
+      "2.0 EX 6AT 4Ptas. (152cv) (L20)",
+      "2.0 SX 6AT 4Ptas. GT Line (152cv) (L20)",
+      "1.6 EX 6AT 5Ptas. (130cv) (L17)",
+      "2.0 SX 6AT 5Ptas. (152cv) (L17)",
+      "2.0 SX 6AT 4Ptas. (152cv) (L17)",
+      "1.6 EX 6MT 4Ptas. (130cv) (L14)",
+      "1.6 EX 6AT 4Ptas. (130cv) (L14)",
+      "Koup 1.6 ELX Coupé",
+      "Koup 2.0 ELX MT Coupé",
+      "Forte 1.6 N EX MT Std. 4Ptas.",
+      "Forte 1.6 N EX MT Full 4Ptas.",
+      "Forte 1.6 N EX MT Premium 4Ptas.",
+      "Forte 2.0 N EX MT Full 4Ptas.",
+      "Forte 2.0 N EX MT Premiun 4Ptas.",
+      "Forte 2.0 N SX AT Elegance 4Ptas."
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 733,
+    "modelo": "K-2500",
+    "versiones": null
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 734,
+    "modelo": "K-2900",
+    "versiones": null
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 974,
+    "modelo": "K3",
+    "versiones": [
+      "1.6 AT6 EX (121cv) 4Ptas.",
+      "1.6 AT6 GT-Line (121cv) 4Ptas.",
+      "Cross 1.6 AT6 EX (121cv) 5Ptas.",
+      "Cross 1.6 AT6 GT-Line (121cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 249,
+    "modelo": "Mohave",
+    "versiones": [
+      "3.8 V6 AT (275hp)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 250,
+    "modelo": "Picanto",
+    "versiones": [
+      "1.1 N MT (65cv) (L06)",
+      "1.1 N AT Full (65cv) (L06)",
+      "1.2 N MT (85hp) (L12)",
+      "1.2 N AT (85hp) (L12)",
+      "1.2 N EX MT (85hp) (L15)",
+      "1.2 N EX AT (85hp) (L15)",
+      "1.2 N EX AT (85hp) (L18)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 251,
+    "modelo": "Rio",
+    "versiones": [
+      "1.4 EX MT Full (100cv) (L19)  5Ptas.",
+      "1.4 EX AT Full (100cv) (L19) 5Ptas.",
+      "1.6 SX AT Premium (123cv) (L19) 5Ptas.",
+      "1.6 EX MT (123cv) (L18) 5Ptas.",
+      "1.6 EX AT (123cv) (L18) 5Ptas.",
+      "1.6 SX AT (123cv) (L18) 5Ptas.",
+      "1.4 EX MT (109cv) (L13) 5Ptas.",
+      "1.4 EX AT (109cv) (L13) 5Ptas.",
+      "EX 1.6 4Ptas.",
+      "EX 1.6 5Ptas."
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 252,
+    "modelo": "Rondo",
+    "versiones": [
+      "2.0 N Full AT",
+      "2.0 CRDI STD MT",
+      "2.0 CRDI Full MT",
+      "2.0 CRDI Full AT"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 253,
+    "modelo": "Seltos",
+    "versiones": [
+      "1.5 MT (116cv)",
+      "1.6 EX AT (123cv)",
+      "1.6 LX AT (123cv)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 255,
+    "modelo": "Sorento",
+    "versiones": [
+      "2.2 CRDi DCT SX 4x4 (202cv) (L22)",
+      "2.4 N 4x2 AT (172hp) (L18)",
+      "2.2 CRDi 4x2 AT (197hp) (L18)",
+      "2.2 CRDi 4x4 AT (197hp) (L18)",
+      "2.2 CRDi 4x4 AT GT-Line (197hp) (L18)",
+      "2.2 CRDi 4x2 AT (197hp) (L16)",
+      "2.2 CRDi 4x4 AT (197hp) (L16)",
+      "2.4 N 4x2 AT (174hp) (L13)",
+      "2.4 N 4x4 AT Full (174hp) (L10)",
+      "2.4 N 4x4 AT Premium (174hp) (L13)",
+      "2.2 CRDi STD MT (197cv) (L10)",
+      "2.2 CRDi Full AT (197cv) (L10)",
+      "2.2 CRDi Premium AT (197cv) (L10)",
+      "EX 2.5 CRDI STD MT (170hp / 140hp) (L07)",
+      "EX 3.8 Nafta Full AT Sport Mode V6 (265hp) (L07)"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 256,
+    "modelo": "Soul",
+    "versiones": [
+      "1.6 EX 6AT Premium (129cv) (L16)",
+      "1.6 EX 6AT Full (129cv) (L16)",
+      "1.6 EX 6MT (129cv) (L14)",
+      "1.6 EX 6AT (129cv) (L14)",
+      "1.6 N MT Classic",
+      "1.6 N MT Pop",
+      "1.6 N AT Pop",
+      "1.6 N MT Rock",
+      "1.6 N AT Rock"
+    ]
+  },
+  {
+    "marca": "KIA",
+    "modeloId": 254,
+    "modelo": "Sportage",
+    "versiones": [
+      "EX 1.6T 7AT 4x2 (178cv) (L23)",
+      "X-Line 1.6T 7AT 4x4 (178cv) (L23)",
+      "LX 2.0 N AT 4x2 (155cv) (L19)",
+      "EX 2.0 N AT 4x2 Premium (155cv) (L19)",
+      "EX 2.0 N AT 4x4 (155cv) (L19)",
+      "SX 2.0 N AT 4x4 (155cv) (L19)",
+      "EX 2.0 CRDI AT 4x2 (185cv) (L19)",
+      "EX 2.0 CRDI MT 4x4 Full (185cv)",
+      "EX 2.0 CRDI AT 4x4 Full (185cv)",
+      "EX 2.0 CRDI AT 4x4 GT-Line (185cv) (L19)",
+      "EX 2.0 N AT 4x2 (155cv) (L16)",
+      "EX 2.0 N AT 4x4 (155cv) (L16)",
+      "EX 2.0 CRDI AT 4x2 (185cv) (L16)",
+      "EX 2.0 CRDI AT 4x4 (185cv) (L16)",
+      "EX 2.0 N MT 4x2 (155cv) (L11)",
+      "EX 2.0 N AT 4x2 (155cv) (L11)",
+      "EX 2.0 N MT 4x4 (155cv) (L11)",
+      "EX 2.0 N AT 4x4 (155cv) (L11)",
+      "EX 2.0 N MT 4x2",
+      "EX 2.0 N MT 4x4 Full",
+      "EX 2.0 CRDI MT 4x2",
+      "EX 2.0 CRDI MT 4x4 Full",
+      "EX 2.0 CRDI AT 4x4 Full"
+    ]
+  },
+  {
+    "marca": "LAND ROVER",
+    "modeloId": 257,
+    "modelo": "Defender",
+    "versiones": [
+      "110 P400e HSE X-Dynamic (330cv)",
+      "130 2.2 Pick up",
+      "110 SW 2.4 MT 5S",
+      "110 SW 2.4 MT 7S",
+      "110 SW 2.2 Special Edition (122cv)"
+    ]
+  },
+  {
+    "marca": "LAND ROVER",
+    "modeloId": 258,
+    "modelo": "Discovery",
+    "versiones": [
+      "Sport 2.0T S (240cv)",
+      "Sport 2.0T SE (240cv)",
+      "Sport 2.0T HSE (240cv)",
+      "Sport 2.0T HSE Black (240cv)",
+      "5 - HSE 3.0N V6",
+      "5 - HSE 3.0D V6",
+      "4  2.7 TDV6 SE (190cv)",
+      "4 - 2.7 TDV6 HSE (190cv)",
+      "4 - 3.0 TDV6 HSE",
+      "4 - 3.0 SDV6 HSE",
+      "4 - 3.0 SDV6 HSE Black Edition"
+    ]
+  },
+  {
+    "marca": "LAND ROVER",
+    "modeloId": 259,
+    "modelo": "Freelander",
+    "versiones": [
+      "II - 2.0 S Plus (240cv)",
+      "II - 2.0 HSE (240cv)",
+      "II - 2.2 TD4 S MT",
+      "II - 2.2 TD4 S AT",
+      "II - 2.2 TD4 S AT Plus",
+      "II - 2.2 TD4 SE AT",
+      "II - 2.2 TD4 HSE AT",
+      "II - 3.2 i6 S AT",
+      "II - 3.2 i6 HSE AT"
+    ]
+  },
+  {
+    "marca": "LAND ROVER",
+    "modeloId": 260,
+    "modelo": "Range Rover",
+    "versiones": [
+      "4.4 Vogue SE SDV8",
+      "5.0 Vogue SE V8",
+      "4.2 V8 Vogue S/C",
+      "3.6 TDV8 HSE",
+      "4.4 TDV8 HSE",
+      "Sport II 3.0 S/C SE V6",
+      "Sport II 3.0 S/C HSE V6",
+      "Sport II 5.0 S/C HSE V8",
+      "Sport II 3.0 SDV6 SE",
+      "Sport II 3.0 SDV6 HSE",
+      "Sport 3.0 TDV6 HSE (L10)",
+      "Sport 5.0 HSE V8 (L10)",
+      "Sport 4.2 V8 (L05)",
+      "Sport 2.7 TDV6 HSE AT (L05)",
+      "Sport 3.6 TDV8 HSE AT (L05)",
+      "Evoque SE Hybrid (2.0T/48V) (300hp) (L20)",
+      "Evoque R-Dynamic Hybrid (2.0T/48V) (300hp) (L20)",
+      "Evoque HST Hybrid (2.0T/48V) (300hp) (L20)",
+      "Evoque 2.0T Pure Coupe Dynamic 3Ptas.",
+      "Evoque 2.0T SE 5Ptas.",
+      "Evoque 2.0T Pure SE Plus 5Ptas.",
+      "Evoque 2.0T HSE 5Ptas.",
+      "Evoque 2.0T Convetible",
+      "Evoque 2.0T Prestige (240cv) 5Ptas.",
+      "Evoque 2.0T Prestige Plus (240cv) 5Ptas.",
+      "Evoque 2.0T Black Edition (240cv) 5Ptas.",
+      "Evoque 2.2 SD4 Prestige 5Ptas.",
+      "Velar 2.0T S (250hp)",
+      "Velar 2.0T S+ (250hp)",
+      "Velar 2.0T S R-Dinamic (250hp)",
+      "Velar 2.0T S+ (300hp)",
+      "Velar 3.0 S R-Dinamic (380hp)",
+      "Velar 2.0TD S (240hp)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 262,
+    "modelo": "ES",
+    "versiones": [
+      "300h Luxury (181cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 263,
+    "modelo": "GS",
+    "versiones": [
+      "350 F-Sport 8AT (315cv)",
+      "450h Luxury CVT (342cv)",
+      "450h F-Sport CVT (342cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 261,
+    "modelo": "IS",
+    "versiones": [
+      "300h Luxury (181cv)",
+      "300 F-Sport (245cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 264,
+    "modelo": "LC",
+    "versiones": [
+      "LC 500 Coupé (477cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 265,
+    "modelo": "LS",
+    "versiones": [
+      "500h F-Sport 10AT (354cv)",
+      "500h Executive 10AT (354cv"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 266,
+    "modelo": "NX",
+    "versiones": [
+      "350 F-Sport 6AT (235cv)",
+      "350h Luxury CVT (197cv)",
+      "300 F-Sport 6AT (235cv)",
+      "300h Luxury CVT (197cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 267,
+    "modelo": "RC",
+    "versiones": [
+      "350 F-Sport (315cv)",
+      "350 F-Sport Mark Levinson (315cv)"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 268,
+    "modelo": "RX",
+    "versiones": [
+      "350 F-SPORT (L23)",
+      "500h F-SPORT+ (L23)",
+      "350 F-SPORT",
+      "450h F-SPORT",
+      "450h LUXURY"
+    ]
+  },
+  {
+    "marca": "LEXUS",
+    "modeloId": 269,
+    "modelo": "UX",
+    "versiones": [
+      "250h Dynamic (181cv)",
+      "250h (181cv)",
+      "250h F-Sport (181cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 270,
+    "modelo": "Foison",
+    "versiones": [
+      "Truck 1.3 Cabina Simple c/ caja playa (92cv)",
+      "Cargo 1.3 Furgón (92cv)",
+      "Box 1.3 Furgón con caja paq.(92cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 271,
+    "modelo": "M7",
+    "versiones": [
+      "2.0 CVT (140cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 810,
+    "modelo": "Motos",
+    "versiones": null
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 272,
+    "modelo": "MyWay",
+    "versiones": [
+      "1.8 MT (132cv)",
+      "1.8 AT (132cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 273,
+    "modelo": "X50",
+    "versiones": [
+      "1.5 MT Full Plus (102cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 274,
+    "modelo": "X60",
+    "versiones": [
+      "1.8 MT Full Plus (132cv)"
+    ]
+  },
+  {
+    "marca": "LIFAN",
+    "modeloId": 275,
+    "modelo": "X70",
+    "versiones": [
+      "2.0 MT (140cv)",
+      "2.0 CVT (140cv)"
+    ]
+  },
+  {
+    "marca": "MASERATI",
+    "modeloId": 277,
+    "modelo": "Ghibli",
+    "versiones": [
+      "Ghibli",
+      "S",
+      "S Q4"
+    ]
+  },
+  {
+    "marca": "MASERATI",
+    "modeloId": 278,
+    "modelo": "Gran Turismo",
+    "versiones": [
+      "GT"
+    ]
+  },
+  {
+    "marca": "MASERATI",
+    "modeloId": 279,
+    "modelo": "Levante",
+    "versiones": [
+      "Q4",
+      "S Q4",
+      "GTS",
+      "Trofeo"
+    ]
+  },
+  {
+    "marca": "MASERATI",
+    "modeloId": 276,
+    "modelo": "Quattroporte",
+    "versiones": [
+      "S Q4",
+      "Gran Lusso",
+      "Gran Sport",
+      "GTS V8",
+      "DS / AU",
+      "DS / AU Sport GT",
+      "DS / AU Executive GT"
+    ]
+  },
+  {
+    "marca": "MCLAREN",
+    "modeloId": 280,
+    "modelo": "Modelo",
+    "versiones": [
+      "570 S",
+      "600 LT"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 281,
+    "modelo": "AMG",
+    "versiones": [
+      "A 35 4Matic MHEV (306cv) Hatchback",
+      "A 35 4Matic (306cv) Hatchback",
+      "A 35 4Matic MHEV (306cv) Sedán",
+      "A 35 4Matic (306cv) Sedán",
+      "A 45 4Matic (360cv) Hatchback",
+      "A 45 S 4Matic (421cv) Hatchback",
+      "C 43 4Matic (408cv) Sedán",
+      "C 43 4Matic (390cv) Sedán",
+      "C 43 4Matic (390cv) Coupé",
+      "C 63 S (510cv) Sedán",
+      "C 63 (457cv) Sedán",
+      "C 63 S (510cv) Coupé",
+      "C 63 (457cv) Coupé",
+      "CLA 45 4MATIC (360cv)",
+      "CLE 53 AT9 4Matic+ MHEV (449cv) Coupe",
+      "CLS 63 (557cv) Sedán",
+      "E 53 Coupé 4Matic (435cv MHEV)",
+      "E 63 S 4Matic (612cv) Sedán",
+      "E 63 (525cv) Sedán",
+      "G 63 4.0BT AT9 4Matic MHEV (485cv)",
+      "GLA 45 4Matic (381cv)",
+      "GLC 43 4Matic (390cv)",
+      "GLC 43 4Matic (367cv)",
+      "GLC 63 S 4Matic (510cv)",
+      "GLC Coupé 43 4Matic MHEV (421cv)",
+      "GLC Coupé 43 4Matic (390cv)",
+      "GLC Coupé 43 4Matic (367cv)",
+      "GLC Coupé 63 S 4Matic (510cv)",
+      "GLE 63 S (585cv)",
+      "GLE Coupé 53 4Matic+ MHEV (435cv)",
+      "GLE Coupé 63 S 4Matic (585cv)",
+      "GT C (557cv) Roadster",
+      "GT4 63 S (557cv) 4Ptas.",
+      "GT R (585cv)",
+      "GTs (510cv)",
+      "ML 63 (510cv)",
+      "SL 63 S E Performance MEHV (816cv) Roadster",
+      "SL 63 Roadster (571cv)",
+      "SL 65 V12 Biturbo (612cv) Coupé",
+      "SLC 43 (367cv) Roadster",
+      "SLK 55 (421cv/360cv) Roadster",
+      "SLS 6.2 V8 (571cv) Coupé"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 742,
+    "modelo": "Buses",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 283,
+    "modelo": "Clase A",
+    "versiones": [
+      "200 Style 7AT (163cv) Hatchback",
+      "200 Progressive 7AT (163cv) Hatchback",
+      "250 AMG-Line (224cv) Hatchback",
+      "A200 Style 7AT (163cv) (L18) Sedan",
+      "A200 Progressive 7AT (163cv) (L18) Sedan",
+      "A250 AMG-Line (224cv) (L18) Sedan",
+      "A200 BlueEfficiency MT Style (156cv) (L13)",
+      "A200 BlueEfficiency MT Urban (156cv) (L13)",
+      "A200 BlueEfficiency MT Urban Thermotronic (156cv) (L13)",
+      "A200 BlueEfficiency AT Urban (156cv) (L13)",
+      "A200 BlueEfficiency AT Urban Thermotronic (156cv) (L13)",
+      "A250 BlueEfficiency AT AMG-Line (211cv) (L13)",
+      "A250 BlueEfficiency AT Sport (211cv) (L13)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 284,
+    "modelo": "Clase B",
+    "versiones": [
+      "180 Nafta MT (116cv)",
+      "180 Nafta AT (116cv)",
+      "200 Style AT (136cv) Sports Tourer",
+      "200 Progressive AT (136cv) Sports Tourer",
+      "200 BlueEfficiency MT (156cv) (L12)",
+      "200 BlueEfficiency City MT (156cv) (L12)",
+      "200 BlueEfficiency City AT (156cv) (L12)",
+      "200 BlueEfficiency Urban AT (156cv) (L12)",
+      "200 BlueEfficiency Sport MT (156cv) (L12)",
+      "200 BlueEfficiency Sport AT (156cv) (L12)",
+      "200 BlueEfficiency 2014 Edition MT (156cv) (L12)",
+      "200 BlueEfficiency 2016 Edition AT (156cv) (L12)",
+      "200 Nafta MT (136cv)",
+      "200 Nafta Turbo Sport MT (193cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 285,
+    "modelo": "Clase C",
+    "versiones": [
+      "280 AT Avantgarde (W 204) Sedán",
+      "300 AT Avantgarde (W 204) Sedán",
+      "300 AT Elegance (W 204) Sedán",
+      "350 AT Avantgarde Sport (W 204) Sedán",
+      "350 AT Elegance (W 204) Sedán",
+      "220 CDI BlueEffi. AT Avantgarde (170cv) (W 204) Sedán",
+      "220 CDI BlueEffi. AT Elegance (170cv) (W 204) Sedán",
+      "200 Kompressor MT Avantgarde (W 204) Sedán",
+      "200 Kompressor MT Avantgarde TC (W 204) Sedán",
+      "200 Kompressor MT Avantgarde Plus (W 204) Sedán",
+      "200 Kompressor AT Avantgarde (W 204) Sedán",
+      "200 Kompressor AT Avantgarde (S 204) Touring",
+      "200 BlueEffi. MT City (184cv) (W 204) (L11) Sedán",
+      "200 BlueEffi. MT Edition C (184cv) (W 204) (L11) Sedán",
+      "200 BlueEffi. AT City (184cv) (W 204) (L11) Sedán",
+      "200 BlueEffi. AT Edition C (184cv) (W 204) (L11) Sedán",
+      "200 CGI BlueEffi. MT Avantgarde (184cv) (W 204) (L11) Sedán",
+      "200 CGI BlueEffi. AT Avantgarde (184cv) (W 204) (L11) Sedán",
+      "200 AT Avantgarde (184cv) (W 205) Sedán",
+      "250 AT AMG-Line (211cv) (W205) Sedán",
+      "250 BlueEffi. AT Style (211cv) (W 205) (L15) Sedán",
+      "250 BlueEffi. AT Avantgarde (211cv) (W 205) (L15) Sedán",
+      "250 BlueEffi. AT Avantgarde (184cv) (W 204) (L12) Sedán",
+      "250 BlueEffi.AT Avantgarde Edition C (184cv) (W 204) (L12) Sedán",
+      "250 BlueEffi. AT Avantgarde Sport (204cv) (W 204) (L11) Sedán",
+      "350 BlueEffi. AT Avantgarde Sport (306cv) (W 204) (L11) Sedán",
+      "350 BlueEffi.AT Avant.Sport T.Panor. (306cv) (W 204) (L11) Sedán",
+      "400 4Matic AMG-Line (333cv) (W205) Sedán",
+      "220 CDI BlueEffi. AT Avantgarde (170cv) (W 204) (L11) Sedán",
+      "250 BlueEffi. AT City Sport (204cv) (C204) (L11) Coupé",
+      "300 AMG Line 9G-Tronic (258cv-48cv MHEV) Sedán",
+      "250 BlueEffi. AT Avantgarde Sport (204cv) (C204) (L11) Coupé",
+      "300 AT AMG-Line (258cv) (W205) Sedán",
+      "300 City AT (204cv) (C205) Coupé",
+      "300 AT AMG-Line (258cv) (C205) Coupé",
+      "300 AT AMG-Line (245cv) (C205) Coupé",
+      "400 4Matic AMG-Line (333cv) (W205) Coupé",
+      "300 AT AMG-Line (258cv) (A205) Cabrio"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 286,
+    "modelo": "Clase CLA",
+    "versiones": [
+      "200 1.3T AT Progressive (163cv)",
+      "200 MT Urban (156cv)",
+      "200 AT Urban (156cv)",
+      "250 AT Sport (211cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 287,
+    "modelo": "Clase CLC",
+    "versiones": [
+      "250 MT Sportcoupé",
+      "350 AT Sportcoupé"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 288,
+    "modelo": "Clase CLS",
+    "versiones": [
+      "350 BlueEfficiency AT Sport (306cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 289,
+    "modelo": "Clase E",
+    "versiones": [
+      "350 Elegance AT Sedán",
+      "350 Avantgarde AT Sedán",
+      "250 CGI BlueEfficiency AT Avantgarde City R17'' Sedán (204cv)",
+      "250 CGI BlueEfficiency AT Avantgarde City R18'' Sedán (204cv)",
+      "250 BlueEfficiency AT Avantgarde Sedán (204cv)",
+      "250 BlueEfficiency AT Avantgarde Sport Sedán (204cv)",
+      "300 Elegance Sedán",
+      "300 Avantgarde Sport Sedán",
+      "350 Elegance AT Sedán (272cv)",
+      "350 Avantgarde Sport AT Sedán (306cv) (L13)",
+      "350 Avantgarde Sport AT Sedán (272cv)",
+      "400 Avantgarde Sport AT Sedán (333cv)",
+      "400 4Matic AMG-Line Sedán (333cv)",
+      "450 4Matic AMG-Line Sedán MHEV (367cv)",
+      "500 Elegance Sedán",
+      "500 Guard Sedán (408cv)",
+      "500 Guard Sedán",
+      "220d 4Matic All-Terrain (194cv) Wágon",
+      "350 Elegance Coupé (272cv)",
+      "350 BlueEfficiency AT Sport Coupé (306cv)",
+      "350 Sport Coupé (272cv)",
+      "400 4Matic AMG-Line Coupé (333cv)",
+      "450 4Matic AMG-Line Coupé (367cv)",
+      "500 Sport Coupé"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 290,
+    "modelo": "Clase G",
+    "versiones": [
+      "500 (422cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 291,
+    "modelo": "Clase GL",
+    "versiones": [
+      "500 4.6 V8 4Matic (435cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 292,
+    "modelo": "Clase GLA",
+    "versiones": [
+      "200 Progressive (163cv)",
+      "200 Urban AT (156cv)",
+      "250 AMG-Line 4Matic (224cv)",
+      "250 AMG-Line 4Matic (211cv)",
+      "250 Urban 4Matic (211cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 293,
+    "modelo": "Clase GLB",
+    "versiones": [
+      "200 Advance (163cv)",
+      "250 Progressive 4Matic  (224cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 294,
+    "modelo": "Clase GLC",
+    "versiones": [
+      "300 Urban 4Matic (241cv)",
+      "300 4Matic (241cv)",
+      "300 AMG-Line 4Matic (258cv)",
+      "300 4Matic Off-Road MHEV (258cv) (L24)",
+      "300 4Matic Off-Road MHEV (258cv)",
+      "300 Coupé 4Matic AMG-Line MHEV (258cv) (L24)",
+      "300 Coupé 4Matic AMG-Line (258cv)",
+      "350e Urban 4Matic (211cv+109cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 295,
+    "modelo": "Clase GLE",
+    "versiones": [
+      "400 4Matic Sport (333cv)",
+      "450 4Matic AMG Line (367cv Mild-Hybrid)",
+      "450 4Matic E-ABC (367cv)",
+      "500 4Matic Guard (455cv)",
+      "400 Coupé 4Matic Sport (333cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 296,
+    "modelo": "Clase GLK",
+    "versiones": [
+      "300 BlueEfficiency (247cv) (L13)",
+      "300 BlueEfficiency Sport (247cv) (L13)",
+      "300 City (231cv)",
+      "300 Sport (231cv)",
+      "280 3.0N 7G-Tronic 4Matic Nature (231cv)",
+      "280 3.0N 7G-Tronic 4Matic Sport (231cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 297,
+    "modelo": "Clase GLS",
+    "versiones": [
+      "500 4Matic AMG-Line (455cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 298,
+    "modelo": "Clase ML",
+    "versiones": [
+      "500 4Matic Sport (L06)",
+      "350 BlueEffi. 4Matic AT Sport (L13) (306cv)",
+      "350 BlueEffi. 4Matic AT Sport T.Panor. (L13) (306cv)",
+      "350 4Matic Sport (L09) (272cv)",
+      "400 4Matic Sport (333cv)",
+      "500 4Matic Sport (L09)",
+      "350 CDI 4Matic Sport (L09) (224cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 299,
+    "modelo": "Clase S",
+    "versiones": [
+      "500L 4Matic AMG-Line LWB MHEV (435cv)",
+      "500L 4Matic AMG-Line (235cv)",
+      "500L BlueEfficiency Sedán (435cv) (W221)",
+      "500L Sedán (W221)",
+      "500 L 4.6 V8 5Pzas. (455cv)",
+      "500 L 4.6 V8 4Pzas. (455cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 300,
+    "modelo": "Clase SL",
+    "versiones": [
+      "500 Roadster (Facelift)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 301,
+    "modelo": "Clase SLK",
+    "versiones": [
+      "200 CGI Blue Efficiency AT Roadster (184cv)",
+      "200 Kompressor MT Roadster",
+      "200 Kompressor MT Sport Roadster",
+      "250 CGI Blue Efficiency AT City Roadster (204cv)",
+      "250 Blue Efficiency AT Roadster (204cv)",
+      "350 Blue Efficiency AT Sport Roadster (306cv)",
+      "350 AT Roadster",
+      "350 AT AMG Edition Roadster"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 282,
+    "modelo": "EQA",
+    "versiones": [
+      "350 4Matic (292cv)"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 738,
+    "modelo": "Livianos",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 739,
+    "modelo": "Medianos",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 741,
+    "modelo": "Pesados",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 740,
+    "modelo": "Semipesados",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 737,
+    "modelo": "Sprinter",
+    "versiones": null
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 302,
+    "modelo": "Viano",
+    "versiones": [
+      "2.2 CDI Trend AT 7 Pass (150cv) (L11)",
+      "2.2 CDI Ambiente AT 7 Pass (150cv) (L11)",
+      "2.2 CDI Trend MT 7 Pass",
+      "2.2 CDI Trend AT 7 Pass",
+      "2.2 CDI Ambiente AT 6 Pass",
+      "2.2 CDI Ambiente AT 7 Pass"
+    ]
+  },
+  {
+    "marca": "MERCEDES BENZ",
+    "modeloId": 303,
+    "modelo": "Vito",
+    "versiones": [
+      "111 Furgón V1",
+      "111 Furgón V2 / V1 AA",
+      "111 Furgón Plus",
+      "111 Furgón Mixto AA",
+      "111 Furgón Mixto Plus AA",
+      "119 Combi 2.0T MT (184cv)",
+      "119 Tourer 2.0T MT 7+1 (184cv)",
+      "121 Tourer AT",
+      "121 Tourer AT 7+1 Plus"
+    ]
+  },
+  {
+    "marca": "MINI",
+    "modeloId": 304,
+    "modelo": "Cooper",
+    "versiones": [
+      "3Ptas.- C Classic AT (156cv) (L24)",
+      "3Ptas.- S Classic AT (204cv) (L24)",
+      "5Ptas.- C Classic AT (156cv) (L24)",
+      "5Ptas.- S Classic AT (204cv) (L24)",
+      "Countryman C Classic AT (156cv) (L24)",
+      "Countryman S All4 Classic Confort (204cv) (L24)",
+      "Countryman S All4 Favoured (204cv) (L24)",
+      "3Ptas.- Salt (122cv)",
+      "3Ptas.- Chili (122cv)",
+      "3Ptas.- Pepper MT (136cv)",
+      "3Ptas.- Classic AT (136cv) (L22)",
+      "3Ptas.- Pepper AT (136cv)",
+      "3Ptas.- Pepper Wired (136cv)",
+      "3Ptas.- S Pepper (184cv)",
+      "3Ptas.- S Hot MT (184cv)",
+      "3Ptas.- S Hot AT (184cv)",
+      "3Ptas.- S Classic Confort AT (192cv) (L22)",
+      "3Ptas.- S Chili (192cv)",
+      "3Ptas.- John Cooper Works S (211cv)",
+      "3Ptas.- John Cooper Works Confort (231cv) (L22)",
+      "3Ptas.- John Cooper Works (231cv)",
+      "3Ptas.- John Cooper Works Look GP (231cv)",
+      "3Ptas.- John Cooper Works GP (306 cv)",
+      "5Ptas.- Pepper MT (136cv)",
+      "5Ptas.- Classic AT (136cv) (L22)",
+      "5Ptas.- Pepper AT (136cv)",
+      "5Ptas.- Pepper Wired (136cv)",
+      "5Ptas.- S Classic Confort AT (192cv) (L22)",
+      "5Ptas.- S Chili (192cv)",
+      "Clubman S (122cv) Wagon 3Ptas.",
+      "Clubman Pepper Wired (136cv) Wagon 5Ptas.",
+      "Clubman S Chili (192cv) Wagon 5Ptas.",
+      "Countryman One MT (98cv)",
+      "Countryman MT (122cv)",
+      "Countryman SD Pepper MT (143cv)",
+      "Countryman SD Chilli AT (143cv)",
+      "Countryman S MT (184cv)",
+      "Countryman S Pepper AT (184cv)",
+      "Countryman S Chili AT (184cv)",
+      "Countryman S MT All4 (184cv)",
+      "Countryman S AT All4 (184cv)",
+      "Countryman Pepper MT (136cv)",
+      "Countryman Classic AT (136cv) (L22)",
+      "Countryman Pepper AT (136cv)",
+      "Countryman S Classic Confort AT (192cv) (L22)",
+      "Countryman S Chili AT (192cv)",
+      "Countryman S Chili AT All4 (192cv)",
+      "Countryman John Cooper Works Confort All4 (231cv) (L22)",
+      "Countryman John Cooper Works S All4 (231cv)",
+      "Countryman John Cooper Works S All4 (218cv)",
+      "Paceman S AT (184cv)",
+      "Paceman S AT All4 (184cv)",
+      "Coupé (122cv)",
+      "Coupé - S (184cv)",
+      "Coupé - John Cooper Works (211cv)",
+      "Cabrio - (122cv)",
+      "Cabrio - S MT (184cv)",
+      "Cabrio - S Steptronic (184cv)",
+      "Cabrio - S Classic Confort (192cv) (L22)",
+      "Cabrio - S Chili (192cv)",
+      "Cabrio - John Cooper Works S (231cv)",
+      "S Roadster (184cv)"
+    ]
+  },
+  {
+    "marca": "MITSUBISHI",
+    "modeloId": 305,
+    "modelo": "L-200",
+    "versiones": [
+      "C/Doble Sport 2.5 HPE MT (141cv)",
+      "C/Doble Sport 2.5 HPE AT (141cv)",
+      "C/Doble 2.5 DI-D MT (135cv)",
+      "C/Doble 2.5 DI-D AT (135cv)",
+      "C/Doble 3.2.DI-D HPE MT Cuero TC (165cv)",
+      "C/Doble 3.2 DI-D HPE AT Cuero TC (165cv)",
+      "C/Doble 2.4TD GLS AT6 4WD (184cv) (L25)",
+      "C/Doble 2.4 DI-D GLS MT Full (181cv) (L19)",
+      "C/Doble 2.4 DI-D GLS AT (181cv) (L19)",
+      "C/Doble 2.4 DI-D GLS AT Full (181cv) (L19)",
+      "C/Doble 2.4 DI-D HP MT 4WD (181cv)",
+      "C/Doble 2.4 DI-D HP AT 4WD (181cv)",
+      "C/Doble 2.5 HP MT STD. (178cv)",
+      "C/Doble 2.5 HP MT Cuero (178cv)",
+      "C/Doble 2.5 HP AT Cuero (178cv)",
+      "C/Doble 3.2 GLS 4WD MT (170cv)",
+      "C/Doble 3.2 CR DI-D MT Cuero (170cv)",
+      "C/Doble 3.2 CR DI-D AT  Cuero (170cv)"
+    ]
+  },
+  {
+    "marca": "MITSUBISHI",
+    "modeloId": 306,
+    "modelo": "Lancer",
+    "versiones": [
+      "2.0 GLS MT Techo 6ABG (L08)",
+      "2.0 GLS AT Techo 6ABG (L08)",
+      "2.0 GT AT Techo 6ABG (154cv) (L08)",
+      "2.0 GT AT Techo 6ABG Cuero (154cv) (L08)"
+    ]
+  },
+  {
+    "marca": "MITSUBISHI",
+    "modeloId": 307,
+    "modelo": "Montero",
+    "versiones": [
+      "3.2 DI-D GLS AT TC Cuero 3Ptas.",
+      "3.2 DI-D GLS AT TC Cuero 5Ptas. (L07)",
+      "Sport 3.2 DI-D GLS MT TC 5Ptas. (163cv)",
+      "Sport 3.2 DI-D GLS AT TC 5Ptas. (163cv)"
+    ]
+  },
+  {
+    "marca": "MITSUBISHI",
+    "modeloId": 308,
+    "modelo": "Outlander",
+    "versiones": [
+      "2.0 GLX 2WD AT (150cv) (L16)",
+      "2.4 GLS 4WD CVT (184cv) (L25)",
+      "2.4 GLS 4WD CVT (169cv) (L19)",
+      "2.4 GLS 4WD AT TC (169cv) (L16)",
+      "Sport 2.0 GLS 2WD MT (150cv)",
+      "Sport 2.0 GLS 4WD AT (150cv)",
+      "Sport 2.0 GLS 4WD AT Full (150cv)",
+      "2.4 GLS 4WD AT Cuero TC (170cv)",
+      "3.0 V6 GLS AT (220cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 309,
+    "modelo": "370Z",
+    "versiones": [
+      "Coupé 3.7 6MT (333cv)",
+      "Coupé 3.7 7AT (333cv)",
+      "Roadster 3.7 7AT (333cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 310,
+    "modelo": "Altima",
+    "versiones": [
+      "2.5N Advance (182cv)",
+      "2.5N Media tech (182cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 311,
+    "modelo": "Frontier",
+    "versiones": [
+      "2.3D C/Doble 4x2 S 6MT (160cv) (L22)",
+      "2.3D C/Doble 4x2 S 6AT (190cv) (L22)",
+      "2.3D C/Doble 4x2 XE 6MT (190cv) (L22)",
+      "2.3D C/Doble 4x2 XE 6AT (190cv) (L22)",
+      "2.3D C/Doble 4x2 Platinium 6AT (190cv) (L22)",
+      "2.3D C/Doble 4x4 S 6MT (160cv) (L22)",
+      "2.3D C/Doble 4x4 XE 6MT (190cv) (L22)",
+      "2.3D C/Doble 4x4 X-GEAR 6AT (190cv) (L22)",
+      "2.3D C/Doble 4x4 Platinium 6AT (190cv) (L22)",
+      "2.3D C/Doble 4x4 Pro-4X 6AT (190cv) (L22)",
+      "2.3D 6MT C/Doble 4x2 S (160cv) (L18)",
+      "2.3D 6MT C/Doble 4x2 SE (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x2 SE PLUS (190cv) (L18)",
+      "2.3D 7AT C/Doble 4x2 X-Gear (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x2 XE (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x2 LE (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x4 S (160cv) (L18)",
+      "2.3D 6MT C/Doble 4x4 SE (190cv) (L18)",
+      "2.3D 7AT C/Doble 4x4 X-Gear (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x4 XE (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x4 LE (190cv) (L18)",
+      "2.3D 7AT C/Doble 4x4 LE (190cv) (L18)",
+      "2.3D 7AT C/Doble 4x4 X-Gear Plus (190cv) (L18)",
+      "2.3D 6MT C/Doble 4x2 SE (190cv) (NP300) (L16)",
+      "2.3D 6MT C/Doble 4x2 SE PLUS (190cv) (NP300) (L16)",
+      "2.3D 6MT C/Doble 4x2 LE (190cv) (NP300) (L16)",
+      "2.3D 6MT C/Doble 4x4 XE (190cv) (NP300) (L16)",
+      "2.3D 6MT C/Doble 4x4 LE (190cv) (NP300) (L16)",
+      "2.3D 7AT C/Doble 4x4 LE (190cv) (NP300) (L16)",
+      "C/Doble 4x4 2.5 TD 6MT LE (172cv) (L13)",
+      "C/Doble 4x4 2.5 TD MT (172cv) (L10)",
+      "C/Doble 4x4 2.5 TD 6MT LE Cuero Premium (172cv) (L13)",
+      "C/Doble 4x4 2.5 TD MT Cuero (172cv) (L10)",
+      "C/Doble 4x4 2.5 TD 5AT LE Attack (172cv) (L13)",
+      "C/Doble 4x4 2.5 TD AT Cuero (172cv) (L10)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 312,
+    "modelo": "Kicks",
+    "versiones": [
+      "1.6 Sense MT (120cv) (L21)",
+      "1.6 Advance MT (120cv) (L21)",
+      "1.6 Advance CVT (120cv) (L21)",
+      "1.6 Advance Plus CVT (120cv) (L21)",
+      "1.6 X-Play CVT (120cv) (L21) DISCONTINUO",
+      "1.6 Exclusive CVT (120cv) (L21)",
+      "1.6 Exclusive CVT Bitono (120cv) (L21)",
+      "1.6 Sense MT (120cv)",
+      "1.6 Advance MT (120cv)",
+      "1.6 Advance CVT (120cv)",
+      "1.6 Advance Ed.Limitada UEFA CVT (120cv)",
+      "1.6 Exclusive CVT (120cv)",
+      "1.6 Exclusive Bitono CVT (120cv)",
+      "1.6 Special Edition CVT (120cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 313,
+    "modelo": "Leaf",
+    "versiones": [
+      "Tekna (149hp-110kW) (L23)",
+      "Tekna (149cv-320Nm)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 314,
+    "modelo": "March",
+    "versiones": [
+      "1.6 Active (107cv) 5Ptas.",
+      "1.6 Sense (107cv) 5Ptas.",
+      "1.6 Sense AT (107cv) 5Ptas.",
+      "1.6 Advance (107cv) 5Ptas.",
+      "1.6 Advance AT (107cv) 5Ptas.",
+      "1.6 Media Tech MT (107cv) 5Ptas.",
+      "1.6 Media Tech AT (107cv) 5Ptas.",
+      "1.6 Visia (107cv) 5Ptas.",
+      "1.6 Visia Plus (107cv) 5Ptas.",
+      "1.6 Acenta ABS (107cv) 5Ptas.",
+      "1.6 SR (107cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 315,
+    "modelo": "Murano",
+    "versiones": [
+      "3.5 N Exclusive CVT (252cv)",
+      "3.5 N Tapine XTronix (260cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 316,
+    "modelo": "Note",
+    "versiones": [
+      "Sense 1.6 16v MT",
+      "Sense 1.6 16v CVT",
+      "Advance 1.6 16v MT",
+      "Advance 1.6 16v CVT",
+      "Exclusive 1.6 16v CVT",
+      "Exclusive 1.6 16v SR CVT"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 317,
+    "modelo": "NP300",
+    "versiones": [
+      "C/Doble 2.5 TD MT 4x2 (131cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 318,
+    "modelo": "Sentra",
+    "versiones": [
+      "Advance 2.0 6MT (147cv) (L20)",
+      "Advance 2.0 CVT (147cv) (L20)",
+      "SR 2.0 CVT (147cv) (L20)",
+      "Exclusive 2.0 CVT (147cv) (L20)",
+      "Sense 1.8 6MT (131cv) (L16)",
+      "Advance 1.8 6MT Safety Pack (131cv) (L19)",
+      "Advance 1.8 6MT (131cv) (L16)",
+      "SR 1.8 CVT Safety Pack (131cv) (L19)",
+      "SR 1.8 CVT (131cv) (L16)",
+      "Exclusive 1.8 CVT Safety Pack (131cv) (L19)",
+      "Exclusive 1.8 CVT (131cv) (L16)",
+      "Acenta 2.0 MT (143cv) 4Ptas.",
+      "Acenta 2.0 CVT (143cv) 4Ptas.",
+      "Tekna 2.0 CVT (143cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 319,
+    "modelo": "Teana",
+    "versiones": [
+      "250 XV",
+      "350 XV"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 320,
+    "modelo": "Tiida",
+    "versiones": [
+      "4Ptas. Visia 1.8 (124cv)",
+      "4Ptas. Acenta 1.8 (124cv)",
+      "4Ptas. Tekna 1.8 Full (124cv)",
+      "5Ptas. Visia 1.8 (126cv)",
+      "5Ptas. Acenta 1.8 (126cv)",
+      "5Ptas. Tekna 1.8 Full (126cv)"
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 321,
+    "modelo": "Versa",
+    "versiones": [
+      "1.6 Sense MT (118cv) 4Ptas. (L20)",
+      "1.6 Sense CVT (118cv) 4Ptas. (L20)",
+      "1.6 Advance (118cv) 4Ptas. (L20)",
+      "1.6 Advance CVT (118cv) 4Ptas. (L20)",
+      "1.6 SR CVT (118cv) 4Ptas. (L20)",
+      "1.6 Exclusive CVT (118cv) 4Ptas. (L20)",
+      "1.6 V-Drive MT (107cv) 4Ptas.",
+      "1.6 V-Drive Plus AT (107cv) 4Ptas.",
+      "1.6 Sense MT (107cv) 4Ptas.",
+      "1.6 Sense AT (107cv) 4Ptas.",
+      "1.6 Advance (107cv) 4Ptas.",
+      "1.6 Advance AT (107cv) 4Ptas.",
+      "1.6 Exclusive AT (107cv) 4Ptas.",
+      "1.6 Visia MT (107cv) 4Ptas.",
+      "1.6 Acenta MT (107cv) 4Ptas.",
+      "1.6 Acenta AT (107cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "NISSAN",
+    "modeloId": 322,
+    "modelo": "X-Trail",
+    "versiones": [
+      "E-Power Exclusive CVT 7Pas. 4x4 (205cv) (L23)",
+      "Advanse 2.5 CVT (170cv) (L18)",
+      "Exclusive 2.5 CVT (170cv) (L18)",
+      "Acenta 2.5 6MT (170cv) (L11)",
+      "Tekna 2.5 X-tronic CVT (170cv) (L11)",
+      "Visia 2.5 MT (170cv) (L/08)",
+      "Visia 2.5 Xtronic CVT (170cv) (L/08)",
+      "Acenta 2.5 MT (170cv) (L/08)",
+      "Acenta 2.5 Xtronic CVT (170cv) (L/08)",
+      "Tekna 2.5 Xtronic CVT (170cv) (L/08)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 326,
+    "modelo": "2008",
+    "versiones": [
+      "1.0T Active CVT (120cv) (L24)",
+      "1.0T Allure CVT (120cv) (L24)",
+      "1.0T GT CVT (120cv) (L24)",
+      "1.6 16v. Active MT (115cv) (L20)",
+      "1.6 16v. Allure MT (115cv) (L20)",
+      "1.6 16v. Feline MT (115cv) (L20)",
+      "1.6 16v. Feline Tiptronic (115cv) (L20)",
+      "1.6 16v. In Concert MT (115cv) (L20)",
+      "1.6 16v. In Concert Tiptronic (115cv) (L20)",
+      "1.6 THP Sport MT (165cv) (L20)",
+      "1.6 THP Sport Tiptronic (165cv) (L20)",
+      "1.6 THP In Concert Tiptronic (165cv) (L20)",
+      "1.6 16v. Crossway MT (115cv)",
+      "1.6 16v. Active MT (115cv)",
+      "1.6 16v. Allure MT (115cv)",
+      "1.6 16v. Allure Tiptronic (115cv)",
+      "1.6 16v. Feline MT (115cv)",
+      "1.6 16v. Feline Tiptronic (115cv)",
+      "1.6 16v. Feline Tiptronic TC (115cv)",
+      "1.6 THP Sport MT (165cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 323,
+    "modelo": "206",
+    "versiones": [
+      "5Ptas. 1.4 Active / EdG Géneration",
+      "5Ptas. 1.4 Allure / EdG Géneration Plus"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 324,
+    "modelo": "207",
+    "versiones": [
+      "Compact 3Ptas. 1.4 N Active / XR (75cv)",
+      "Compact 3Ptas. 1.6 N Feline / XT (110cv)",
+      "Compact 3Ptas. 1.6 XT Quiksilver (110cv)",
+      "Compact 3Ptas. 1.6 N Griffe / XT Premium (110cv)",
+      "Compact 4Ptas. 1.4 N Active / XR (75cv)",
+      "Compact 4Ptas. 1.4 N Allure / XS (75cv)",
+      "Compact 4Ptas. 1.6 N Feline / XT (110cv)",
+      "Compact 4Ptas. 1.4 HDI Active / XR (70cv)",
+      "Compact 4Ptas. 1.4 HDI Allure / XS (70cv)",
+      "Compact 4Ptas. 1.4 HDI Feline / XT (70cv)",
+      "Compact 4Ptas. 1.9D XR (70cv)",
+      "Compact 4Ptas. 1.9D XS (70cv)",
+      "Compact 4Ptas. 2.0 HDI XT (90cv)",
+      "Compact 5Ptas. 1.4 N Active / XR (75cv)",
+      "Compact 5Ptas. 1.4 N Allure / XS (75cv)",
+      "Compact 5Ptas. 1.4 N Quiksilver (75cv)",
+      "Compact 5Ptas. 1.6 N Allure / XS (110cv)",
+      "Compact 5Ptas. 1.6 N Feline / XT (110cv)",
+      "Compact 5Ptas. 1.6 N Feline / XT Tiptronic (110cv)",
+      "Compact 5Ptas. 1.6 N Griffe / XT Premium (110cv)",
+      "Compact 5Ptas. 1.4 HDI Allure / XS (70cv)",
+      "Compact 5Ptas. 1.4 HDI Feline / XT (70cv)",
+      "Compact 5Ptas. 1.9D XR (70cv)",
+      "Compact 5Ptas. 1.9D XS (70cv)",
+      "Compact 5Ptas. 1.9D XT (70cv)",
+      "Compact 5Ptas. 2.0 HDI XT (90cv)",
+      "Compact SW 1.6 N XS (110cv)",
+      "Compact SW 1.6 N XT (110cv)",
+      "Compact SW 2.0 HDI XT (90cv)",
+      "RC 1.6 16v THP (175cv)",
+      "GTI (156cv) 3Ptas.",
+      "GTI (156cv) 5Ptas.",
+      "CC 1.6 16v THP Coupe Cabriolet (150cv)",
+      "CC 1.6 16v THP Coupe Cabriolet (156cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 325,
+    "modelo": "208",
+    "versiones": [
+      "1.6 Active (115cv) (L24)",
+      "1.6 Allure (115cv) (L24)",
+      "1.6 Allure Pack (115cv) (L24)",
+      "1.6 Allure AT (115cv) (L24)",
+      "1.0T T200 Allure Pack CVT (120cv) (L24)",
+      "1.0T T200 GT CVT (120cv) (L24)",
+      "1.2 Like (L20)",
+      "1.2 New Like",
+      "1.6 Like Pack (L20)",
+      "1.6 Active (L20)",
+      "1.6 Active Tiptronic (L20)",
+      "1.6 Active Pack",
+      "1.6 Active Pack Tiptronic",
+      "1.6 Allure (L20)",
+      "1.6 Allure Tiptronic (L20)",
+      "1.6 Allure Pack",
+      "1.6 Allure Pack Tiptronic",
+      "1.6 Style",
+      "1.6 Style Tiptronic",
+      "1.6 Roadtrip",
+      "1.6 Roadtrip Tiptronic",
+      "1.6 Feline Tiptronic (L20)",
+      "1.2T GT Line Tiptronic (130cv)",
+      "1.2T GT Tiptronic (130cv)",
+      "1.5 N 8v Active (90cv) (L16)",
+      "1.5 N 8v Allure Nav. (L18)",
+      "1.5 N 8v Allure Touch SMEG (90cv) (L16)",
+      "1.6 N 16v Active (115cv) (L18)",
+      "1.6 N 16v Urban (115cv) (L18)",
+      "1.6 N 16v Allure (115cv) (L18)",
+      "1.6 N 16v Allure Tiptronic (115cv) (L18)",
+      "1.6 N 16v Allure Tiptronic Touch SMEG (115cv) (L16)",
+      "1.6 N 16v In Concert (115cv) (L18)",
+      "1.6 N 16v Feline (115cv) (L18)",
+      "1.6 N 16v Feline Tiptronic (115cv) (L18)",
+      "1.6 HDI Allure Plus (92cv) (L20)",
+      "1.6 THP GT (165cv) (L18)",
+      "1.6 THP GTI (208cv) 3Ptas. (L18)",
+      "1.5 N 8v Active (90cv)",
+      "1.5 N 8v Allure (90cv)",
+      "1.5 N 8v Allure Touch (90cv)",
+      "1.6 N 16v Allure (115cv)",
+      "1.6 N 16v Allure Touch (115cv)",
+      "1.6 N 16v Allure Tiptronic (115cv)",
+      "1.6 N 16v Feline (115cv)",
+      "1.6 N 16v Feline Pack Cuir (115cv)",
+      "1.6 THP GTI (200cv) 3Ptas.",
+      "1.6 THP XY (156cv) 3Ptas."
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 330,
+    "modelo": "3008",
+    "versiones": [
+      "1.6TD GT Pack Hybrid4 AT8 4WD (200cv) (110cv-113cv)",
+      "1.6 THP Allure AT6 (165cv) (L21)",
+      "1.6 THP GT Pack AT6 (165cv) (L21)",
+      "2.0 HDI GT Pack AT8 (150cv) (L21)",
+      "1.6 THP Allure 6AT (165cv) (L17)",
+      "1.6 THP GT Line 6AT (165cv) (L17)",
+      "2.0 HDI GT Line 6AT (150cv) (L17)",
+      "1.6T Allure 6MT (156cv)",
+      "1.6T Allure Tiptronic (156cv)",
+      "1.6T Feline 6MT (156cv)",
+      "1.6T Feline Tiptronic (156cv)",
+      "1.6T Roland Garros 6MT (156cv)",
+      "1.6T Roland Garros Tiptronic (156cv)",
+      "1.6T Premium 6MT (156cv)",
+      "1.6T Premium Plus 6MT (156cv)",
+      "1.6T Premium Plus Tiptronic (156cv)",
+      "1.6T Premium Plus Tiptronic (163cv)",
+      "2.0 HDI Feline Tiptronic (163cv)",
+      "2.0 HDI Premium Plus Tiptronic (163cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 327,
+    "modelo": "301",
+    "versiones": [
+      "1.6 Allure MT (115cv)",
+      "1.6 Allure Plus MT (115cv)",
+      "1.6 Allure Plus Tiptronic (115cv)",
+      "1.6 HDI Allure MT (92cv)",
+      "1.6 HDI Allure Plus MT (92cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 328,
+    "modelo": "307",
+    "versiones": [
+      "4Ptas. 1.6 N XS (110cv) (L06)",
+      "4Ptas. 1.6 N XT (110cv) (L06)",
+      "4Ptas. 2.0 Hdi XT (110cv) (L06)",
+      "4Ptas. 2.0 Hdi XS (110cv) (L06)",
+      "4Ptas. 2.0 Hdi XS Premium (110cv) (L06)",
+      "5Ptas. 1.6 N XR (110cv) (L06)",
+      "5Ptas. 1.6 N XS (110cv)",
+      "5Ptas. 1.6 N Live (110cv)",
+      "5Ptas. 1.6 N XT (110cv) (L06)",
+      "5Ptas. 1.6 N XT Premium (110cv) (L06)",
+      "5Ptas. 2.0 N XS Premium (143cv)",
+      "5Ptas. 2.0 N SS La Dolfina (143cv)",
+      "5Ptas. 2.0 Hdi XS (110cv)",
+      "5Ptas. 2.0 Hdi Live (110cv)",
+      "5Ptas. 2.0 Hdi XT (110cv) (L06)",
+      "5Ptas. 2.0 Hdi XT Premium (110cv) (L06)",
+      "5Ptas. 2.0 Hdi XS Premium (110cv) (L06)",
+      "5Ptas. 2.0 Hdi SS La Dolfina (110cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 329,
+    "modelo": "308",
+    "versiones": [
+      "Active 1.6 16v Nav. (115cv) 5Ptas. (L18)",
+      "Active 1.6 16v (115cv) 5Ptas. (L16)",
+      "Active 1.6 16v (115cv) 5Ptas. (L12)",
+      "Allure 1.6 16v (115cv) 5Ptas. (L12)",
+      "Allure Pack 1.6 16v (115cv) 5Ptas. (L20)",
+      "Allure 1.6 16v NAV. (115cv) 5Ptas. (L16)",
+      "Allure 1.6 16v NAV (115cv) 5Ptas. (L12)",
+      "Allure Plus 2.0 16v (143cv) 5Ptas. (L16)",
+      "Feline 2.0 16v MT (143cv) 5Ptas. (L12)",
+      "Feline 2.0 16v Tiptronic (143cv) 5Ptas.",
+      "Feline 1.6 THP MT (163cv) 5Ptas. (L16)",
+      "Alure Pack 1.6 THP Tiptronic (163cv) 5Ptas. (L18)",
+      "Feline 1.6 THP Tiptronic (163cv) 5Ptas. (L20)",
+      "Feline 1.6 THP Tiptronic (163cv) 5Ptas. (L16)",
+      "Roland Garros 1.6 THP Tiptronic (163cv) 5Ptas. (L18)",
+      "Roland Garros 1.6 THP AT (163cv) 5Ptas.",
+      "Sport 1.6 THP AT (163cv) 5Ptas. (L12)",
+      "Active 1.6 HDI (115cv) 5Ptas. (L12)",
+      "Allure 1.6 HDI (115cv) 5ptas.",
+      "Allure Pack 1.6 HDI (115cv) 5Ptas. (L20)",
+      "Allure 1.6 HDI NAV (115cv) 5Ptas. (L16)",
+      "Allure 1.6 HDI NAV (115cv) 5Ptas. (L12)",
+      "Feline 1.6 HDI (115cv) 5Ptas. (L20)",
+      "Feline 1.6 HDI (115cv) 5Ptas. (L16)",
+      "Feline 1.6 HDI (115cv) 5Ptas. (L12)",
+      "Roland Garros 1.6 HDI MT (115cv) 5Ptas. (L18)",
+      "Roland Garros 1.6 HDI MT (115cv) 5Ptas.",
+      "S 1.6 THP 6AT Allure Plus (165cv) 5Ptas.",
+      "S 1.6 THP 8AT GT (225cv) 5Ptas.",
+      "S 1.6 THP 6MT GTI (272cv) 5Ptas.",
+      "S GTI Coupe Franche 1.6 THP 6MT (272cv) 5Ptas.",
+      "GTI 5Ptas. 1.6 THP 6MT (200cv)",
+      "CC 1.6 Turbo THP 6MT (156cv)",
+      "CC 1.6 THP 6MT (152cv) (L09)",
+      "CC 1.6 Turbo THP Tiptronic (163cv)",
+      "CC 1.6 Turbo THP Tiptronic (156cv) (L09)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 333,
+    "modelo": "4008",
+    "versiones": [
+      "2.0 4x4 MT Allure (150cv)",
+      "2.0 4x4 CVT Allure (150cv)",
+      "2.0 4x4 CVT Feline (150cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 331,
+    "modelo": "407",
+    "versiones": [
+      "SR Sport 2.0 (L07)",
+      "SV Sport 2.0 (L07)",
+      "SV Sport 2.2 (L07)",
+      "SV Sport V6 Tiptronic (L07)",
+      "SR Sport 2.0 Hdi (L07)",
+      "SV Sport 2.0 Hdi (L07)",
+      "SV Sport 2.0 Hdi Tiptronic (L07)",
+      "SW SV Sport 2.2 (L07)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 332,
+    "modelo": "408",
+    "versiones": [
+      "Allure 1.6 MT (115cv) 4Ptas. (L20)",
+      "Allure Pack 1.6 MT (115cv) 4Ptas. (L20)",
+      "Allure Plus 1.6 THP MT (163cv) 4Ptas. (L20)",
+      "Allure Pack 1.6 THP Tiptronic (163cv) 4Ptas. (L20)",
+      "Feline 1.6 THP Tiptronic (163cv) 4Ptas. (L20)",
+      "Allure 1.6 HDi MT (115cv) 4Ptas. (L20)",
+      "Allure Pack 1.6 HDi MT (115cv) 4Ptas. (L20)",
+      "Feline 1.6 HDi MT (115cv) 4Ptas. (L20)",
+      "Active 1.6 MT (115cv) 4Ptas. (L15)",
+      "Allure 2.0 MT NAV (143cv) 4Ptas. (L15)",
+      "Allure 1.6 MT (115cv) 4Ptas. (L15)",
+      "Allure Plus 1.6 THP MT (163cv) 4Ptas. (L15)",
+      "Feline 1.6 THP Tiptronic (163cv) 4Ptas. (L15)",
+      "Allure 1.6 HDi MT GPS (115cv) 4Ptas. (L15)",
+      "Feline 1.6 HDi MT (115cv) 4Ptas. (L15)",
+      "Allure 2.0 MT (143cv) 4Ptas.",
+      "Allure 2.0 MT NAV (143cv) 4Ptas.",
+      "Allure 2.0 Tiptronic (143cv) 4Ptas.",
+      "Allure 2.0 Tiptronic NAV (143cv) 4Ptas.",
+      "Allure+ 2.0 MT (143cv) 4Ptas.",
+      "Allure+ 2.0 MT NAV (143cv) 4Ptas.",
+      "Allure+ 2.0 Tiptronic (143cv) 4Ptas.",
+      "Allure+ 2.0 Tiptronic NAV (143cv) 4Ptas.",
+      "Feline 2.0 MT (143cv) 4Ptas.",
+      "Allure 1.6 HDi MT (115cv) 4Ptas.",
+      "Allure 1.6 HDi MT NAV (115cv) 4Ptas.",
+      "Allure+ 1.6 HDi MT (115cv) 4Ptas.",
+      "Allure+ 1.6 HDi MT NAV (115cv) 4Ptas.",
+      "Feline 1.6 HDi MT (115cv) 4Ptas.",
+      "Sport 1.6 THP Turbo Tiptronic (163cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 335,
+    "modelo": "5008",
+    "versiones": [
+      "1.6 THP GT Pack (165cv)",
+      "1.6 THP Allure Tiptronic (165cv) (L18)",
+      "1.6 THP Allure Plus Tiptronic (165cv) (L18)",
+      "2.0 HDI Allure Plus Tiptronic (150cv) (L18)",
+      "2.0 HDI Allure Plus Tiptronic (150cv) (L21)",
+      "1.6 THP 6MT Allure (156cv)",
+      "1.6 THP 6MT Allure Plus (156cv)",
+      "1.6 THP Allure Tiptronic (156cv)",
+      "1.6 THP Feline Tiptronic (156cv) B/Techo"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 334,
+    "modelo": "508",
+    "versiones": [
+      "1.6 T Allure Tiptronic (163cv) (L16) 4Ptas.",
+      "1.6 T Feline Tiptronic (163cv) (L16) 4Ptas.",
+      "2.0 HDi Allure Tiptronic (163cv) (L16) 4Ptas.",
+      "2.0 HDi Feline Tiptronic (163cv) (L16) 4Ptas.",
+      "1.6 T Allure Sec.6 (163cv) 4Ptas.",
+      "1.6 T Allure Sec.6 (163cv) Techo 4Ptas.",
+      "1.6 T Feline Sec.6 (163cv) 4Ptas.",
+      "2.0 HDi Allure AT (163cv) 4Ptas.",
+      "2.0 HDi Feline AT (163cv) 4Ptas.",
+      "2.2 HDi GT AT (204cv) 4Ptas."
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 336,
+    "modelo": "807",
+    "versiones": [
+      "SR 2.0 7 asientos (L08)",
+      "SR 2.0 HDI 7 asientos (L08)",
+      "ST 2.0 HDI 7 asientos (L08)",
+      "ST 2.0 HDI 8 asientos (L08)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 342,
+    "modelo": "Boxer",
+    "versiones": [
+      "2.2 HDI L2H2  Larga Alta (140cv) (L23)",
+      "2.2 HDI L3H2  Larga II Alta (140cv) (L23)",
+      "Chasis 2.2 HDI 440L3 Premium (130cv)",
+      "Chasis 2.2 HDI 435L Premium (130cv) (L17)",
+      "330M 2.8 HDI Larga (L07)",
+      "2.2 HDI 435M Premium (130cv) (L17)",
+      "330M Confort 2.3 HDI Larga (L10)",
+      "330M Confort 2.8 HDI Larga (L07)",
+      "350MH 2.8 HDI Larga Alta (L07)",
+      "2.2 HDI 435MH Premium (130cv) (L17)",
+      "350MH Confort 2.3 HDI Larga Alta (L10)",
+      "350MH Confort 2.8 HDI Larga Alta (L07)",
+      "2.2 HDI 435LH Premium (130cv) (L17)",
+      "350LH Confort 2.3 HDI Larga II Alta (L10)",
+      "350LH Confort 2.8 HDI Larga II Alta (L07)",
+      "Combi 330M Confort 2.8 HDI (L07)",
+      "Minibus 2.2 HDI 440 L4H2 Premium 17+1 (130cv) (L17)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 338,
+    "modelo": "Expert",
+    "versiones": [
+      "1.5TD MT6 (120cv)",
+      "1.6 HDI Premium (115cv)",
+      "1.6 HDI Premium 6Pas. (115cv)",
+      "1.6 HDI Confort",
+      "2.0 HDi Confort"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 339,
+    "modelo": "Hoggar",
+    "versiones": [
+      "1.6 16v XR",
+      "1.6 16v XS",
+      "1.6 16v Escapade / ABS"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 340,
+    "modelo": "Partner",
+    "versiones": [
+      "Furgón Presence 1.6 (115cv) (L17)",
+      "Furgón Confort 1.6 (115cv) (L17)",
+      "Furgón Confort 1.6 5Plz.(115cv) (L17)",
+      "Furgón Confort 1.6 Hdi (92cv) (L17)",
+      "Furgón Confort 1.6 Hdi 5Plz. (92cv) (L17)",
+      "Patagónica 1.6 (115cv) (L17)",
+      "Patagónica 1.6 VTC Plus (115cv) (L17)",
+      "Patagónica 1.6 Hdi (92cv) (L17)",
+      "Patagónica 1.6 Hdi VTC Plus (92cv) (L17)",
+      "Furgón 1.4 N Presence (75cv) (L10)",
+      "Furgón 1.4 N Presence AA (75cv) (L10)",
+      "Furgón 1.4 N Confort (75cv) (L10)",
+      "Furgón 1.4 N Confort ABG (75cv) (L10)",
+      "Furgón 1.4 N Confort 5 As. (75cv) (L10)",
+      "Furgón 1.6 Hdi Presence PLC (90cv) (L10)",
+      "Furgón 1.6 Hdi Presence AA (90cv) (L10)",
+      "Furgón 1.6 Hdi Confort (90cv) (L10)",
+      "Furgón 1.6 Hdi Confort ABG (90cv) (L10)",
+      "Furgón 1.6 Hdi Confort 5 As. (90cv) (L10)",
+      "Patagónica 1.4 N (75cv) (L10)",
+      "Patagónica 1.6 N 16v. VTC (110cv) (L10)",
+      "Patagónica 1.6 N 16v. VTC Plus (110cv) (L10)",
+      "Patagónica 1.6 Hdi (90cv) (L10)",
+      "Patagónica 1.6 Hdi VTC (90cv) (L10)",
+      "Patagónica 1.6 Hdi VTC Plus (90cv) (L10)",
+      "Furgón 1.4 Presence",
+      "Furgón 1.4 Confort AA PLC",
+      "Furgón 1.9D Presence PLC",
+      "Furgón 1.9D Confort AA PLC",
+      "Furgón 1.9D Confort AA PLC ABCP",
+      "Patagónica 1.9D Full AA 2PLC",
+      "Urbana 1.4 Confort AA"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 337,
+    "modelo": "RCZ",
+    "versiones": [
+      "1.6T 6MT (200cv)",
+      "1.6T Tiptronic (200cv)",
+      "1.6T 6MT Carbon Concept (200cv)"
+    ]
+  },
+  {
+    "marca": "PEUGEOT",
+    "modeloId": 341,
+    "modelo": "Traveller",
+    "versiones": [
+      "2.0 HDI Allure 8Pas. (150cv)"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 343,
+    "modelo": "718",
+    "versiones": [
+      "Cayman",
+      "Cayman S",
+      "GTS",
+      "Boxster",
+      "Boxster S",
+      "Boxster GTS",
+      "Cayman GT4 RS",
+      "Spyder"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 344,
+    "modelo": "911",
+    "versiones": [
+      "Carrera",
+      "Carrera Cabriolet",
+      "Carrera S",
+      "Carrera S Cabriolet",
+      "Carrera GTS Cabriolet T-Hybrid",
+      "Carrera GTS Coupé T-Hybrid",
+      "Carrera 4",
+      "Carrera 4 Cabriolet",
+      "Carrera 4 S",
+      "Carrera 4 S Cabriolet",
+      "Carrera 4 GTS Coupé T-Hybrid",
+      "Carrera 4 GTS Cabriolet T-Hybrid",
+      "Targa",
+      "Targa 4S",
+      "Targa 4 GTS T-Hybrid",
+      "Turbo",
+      "Turbo Cabriolet",
+      "Turbo S",
+      "Turbo S Cabriolet",
+      "GT2",
+      "GT2 RS",
+      "GT3",
+      "GT3 RS",
+      "Sport Classic SL"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 345,
+    "modelo": "Boxster",
+    "versiones": [
+      "Boxster",
+      "Boxster S",
+      "Boxster Spyder"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 346,
+    "modelo": "Cayenne",
+    "versiones": [
+      "Cayenne 3.0T (353cv) (L23)",
+      "Cayenne E-Hybrid (470cv) (L23)",
+      "Cayenne S E-Hybrid (519cv) (L23)",
+      "Cayenne Turbo E-Hybrid (739cv) (L23)",
+      "Cayenne Coupe E-Hybrid (470cv) (L23)",
+      "Cayenne Coupé Turbo E-Hybrid (739cv) (L23)",
+      "Cayenne Coupe S E-Hybrid (519cv) (L23)",
+      "Cayenne Coupe 3.0T (353cv) (L23)",
+      "Cayenne S 4.0 V8 (474cv) (L23)",
+      "Cayenne S Coupe 4.0 V8 (474cv) (L23)",
+      "Cayenne GTS Coupe 3.0 V8 (460cv) (L23)",
+      "Cayenne Turbo GT Coupé 4.0 V8 (659cv) (L23)",
+      "Cayenne (290cv)",
+      "Cayenne Coupe (340cv)",
+      "Cayenne S (400cv)",
+      "Cayenne S Tiptronic (340cv)",
+      "Cayenne S Tiptronic (300cv)",
+      "Cayenne S Coupe (440cv)",
+      "Cayenne S Diesel 3.0 V6 Tiptronic (240cv)",
+      "Cayenne S 3.0 V6 (440cv)",
+      "Cayenne S Hybrid 3.0 V6 / 279kW (380cv)",
+      "GTS Tiptronic S (405hp)",
+      "Turbo (550cv)",
+      "Turbo (500cv) (L11)",
+      "Turbo S (500cv)"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 347,
+    "modelo": "Cayman",
+    "versiones": [
+      "Cayman",
+      "Cayman S"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 348,
+    "modelo": "Macan",
+    "versiones": [
+      "Macan",
+      "Macan T",
+      "Macan S",
+      "S Diesel",
+      "Macan GTS",
+      "Macan Turbo (400cv)",
+      "Electric RWD (360cv 265Kw)",
+      "Electric 4 (360cv 265Kw)",
+      "Electric 4S (448cv 330Kw)",
+      "Electric Turbo (448cv 330Kw)"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 349,
+    "modelo": "Panamera",
+    "versiones": [
+      "Panamera (260kW/353PS) (L24)",
+      "4 E-Hydrid (246kW/470PS) (L24)",
+      "4S E-Hydrid (400kW/544PS) (L24)",
+      "Turbo E-Hybrid ((500kW/680PS)) (L24)",
+      "S",
+      "4S",
+      "Turbo",
+      "GTS"
+    ]
+  },
+  {
+    "marca": "PORSCHE",
+    "modeloId": 350,
+    "modelo": "Taycan",
+    "versiones": [
+      "Taycan (326cv)",
+      "Taycan 4S (536cv)",
+      "Taycan Turbo (871cv)",
+      "Taycan Turbo S (938cv)",
+      "Taycan Cross Turismo (871cv)",
+      "Taycan 4S Cross Turismo (536cv)",
+      "Taycan Turbo Cross Turismo (938cv)",
+      "4S (530cv) (L21)",
+      "Turbo S (761cv) (L21)"
+    ]
+  },
+  {
+    "marca": "RAM",
+    "modeloId": 351,
+    "modelo": "1500",
+    "versiones": [
+      "3.0BT AT8 Laramie (426cv)",
+      "3.0BT AT8 Laramie Night Edition (426cv)",
+      "Laramie 5.7 V8 AT8 4x4 (395cv) DISCONTINUO",
+      "Laramie 5.7 V8 AT8 4x4 Night Edition (395cv) DISCONTINUO",
+      "Rebel 5.7 V8 AT8 4x4 MildHybrid (395cv) DISCONTINUO"
+    ]
+  },
+  {
+    "marca": "RAM",
+    "modeloId": 352,
+    "modelo": "2500",
+    "versiones": [
+      "Laramie 6.7TD AT6 4x4 (365cv)",
+      "Laramie 6.7TD AT6 4x4 Night Edition (365cv)",
+      "Laramie 6.7TD AT 4x4 Crew Cab"
+    ]
+  },
+  {
+    "marca": "RAM",
+    "modeloId": 353,
+    "modelo": "Rampage",
+    "versiones": [
+      "2.0T AT9 Rebel 4x4 (272cv)",
+      "2.0T AT9 Laramie 4x4 (272cv)",
+      "2.0T AT9 Laramie 4x4 Night Edition (272cv)",
+      "2.0T AT9 R/T 4x4 (272cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 355,
+    "modelo": "Alaskan",
+    "versiones": [
+      "2.3T Confort MT 4x2 (160cv)",
+      "2.3T Emotion MT 4x2 (190cv)",
+      "2.3T Intens MT 4x2 (190cv)",
+      "2.3T Intens AT 4x2 (190cv)",
+      "2.3T Confort MT 4x4 (160cv)",
+      "2.3T Emotion MT 4x4 (190cv)",
+      "2.3T Intens MT 4x4 NOIR (190cv)",
+      "2.3T Intens AT 4x4 NOIR (190cv)",
+      "2.3T Iconic MT 4x4 (190cv)",
+      "2.3T Iconic AT 4x4 (190cv)",
+      "2.3T Outsider AT 4x4 (190cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 1485,
+    "modelo": "Arkana E-Tech Hybrid",
+    "versiones": [
+      "1.3T AT7 Esprit Alpine MHEV (140cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 356,
+    "modelo": "Captur",
+    "versiones": [
+      "1.6 16v 6MT Life (115cv)",
+      "1.6 16v CVT Intens 1 tono (115cv)",
+      "1.6 16v CVT Intens (115cv)",
+      "1.6 16v CVT Ed.Limit. Le Coq Sportif (115cv)",
+      "1.6 16v CVT Bose (115cv)",
+      "2.0 16v 6MT Zen (143cv)",
+      "2.0 16v 6MT Intens Bitono Nav. Evo. (143cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 358,
+    "modelo": "Clio L/Nueva",
+    "versiones": [
+      "3Ptas. 1.2 Campus / Authentique / Base",
+      "3Ptas. 1.2 Campus Pack / Authentique Pack",
+      "3Ptas. 1.2 Get Up - Serie Limitada",
+      "5Ptas. 1.2 Authentique / Base",
+      "5Ptas. 1.2 Campus Pack I / Authentique Pack I / Pack",
+      "5Ptas. 1.2 Campus Pack II / Authentique Pack II / Pack Plus"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 357,
+    "modelo": "Clio Mío",
+    "versiones": [
+      "3Ptas. 1.2 Work (75cv)",
+      "3Ptas. 1.2 Expression / Pack / Authentique (75cv)",
+      "3Ptas. 1.2 Pack Look / Authentique Pack Look (75cv)",
+      "3Ptas. 1.2 Confort / Expression Pack I (75cv)",
+      "3Ptas. 1.2 Confort ABS ABCP (75cv)",
+      "3Ptas. 1.2 Confort Plus / Expression Pack II (75cv)",
+      "3Ptas. 1.2 Confort Pack / Confort Plus (75cv)",
+      "3Ptas. 1.2 Confort Pack Sat. (75cv)",
+      "3Ptas. 1.2 GT Line (75cv)",
+      "3Ptas. 1.2 Dynamique (75cv)",
+      "5Ptas. 1.2 Confort (75cv)",
+      "5Ptas. 1.2 Confort ABS ABCP (75cv)",
+      "5Ptas. 1.2 Expression (75cv)",
+      "5Ptas. 1.2 Expression Pack I (75cv)",
+      "5Ptas. 1.2 Confort Pack / Plus (75cv)",
+      "5Ptas. 1.2 GT Line (75cv)",
+      "5Ptas. 1.2 Dynamique (75cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 359,
+    "modelo": "Duster",
+    "versiones": [
+      "1.6 4x2 Life (115cv) (L21)",
+      "1.6 4x2 Zen (115cv) (L21)",
+      "1.6 4x2 Intense (115cv) (L21)",
+      "1.6 4x2 Intense CVT (115cv) (L21)",
+      "1.3T 4x2 Iconic CVT (155cv) (L21)",
+      "1.3T 4x2 Outsider CVT (155cv) (L21)",
+      "1.3T 4x4 Iconic (155cv) (L21)",
+      "Fase II 1.6 4x2 Expression (110cv)",
+      "Fase II 1.6 4x2 Dynamique (110cv)",
+      "Fase II 1.6 4x2 Dakar (110cv)",
+      "Fase II 1.6 4x2 Privilege (110cv)",
+      "Fase II 1.6 4x2 Los Pumas (110cv)",
+      "Fase II 2.0 4x2 6MT Privilege (143cv)",
+      "Fase II 2.0 4x2 6MT Dakar (143cv)",
+      "Fase II 2.0 4x4 6MT Privilege (143cv)",
+      "Fase II 2.0 4x4 6MT Dakar (143cv)",
+      "1.6 4x2 Confort / Expression (110cv)",
+      "1.6 4x2 Confort ABS (110cv)",
+      "1.6 4x2 Confort Plus / Dinamique (110cv)",
+      "1.6 4x2 Confort Plus ABS (110cv)",
+      "1.6 4x2 Tech Road (110cv)",
+      "1.6 4x2 Dakar (110cv)",
+      "2.0 4x2 6MT Luxe / Privilege (138cv)",
+      "2.0 4x2 6MT Luxe NAV (138cv)",
+      "2.0 4x2 6MT Los Pumas (138cv)",
+      "2.0 4x4 6MT Luxe / Privilege (138cv)",
+      "2.0 4x4 6MT Luxe NAV (138cv)",
+      "2.0 4x4  Tech Road (138cv)",
+      "2.0 4x4 6MT Los Pumas (138cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 361,
+    "modelo": "Fluence",
+    "versiones": [
+      "1.6 Confort MT 2ABG ABS (110cv)",
+      "1.6 Confort Plus MT (110cv)",
+      "1.6 Dynamique MT (110cv)",
+      "1.6 Dynamique Pack MT (110cv)",
+      "1.6 Luxe MT (110cv)",
+      "2.0 Dynamique 6MT 6ABG ABS (143cv)",
+      "2.0 Luxe 6MT 6ABG ABS (143cv)",
+      "2.0 Luxe 6MT Rlink (143cv)",
+      "2.0 Luxe 6MT Rlink Cuir (143cv)",
+      "2.0 Luxe Pack 6MT (143cv)",
+      "2.0 Luxe Pack 6MT Cuero (143cv)",
+      "2.0 Luxe CVT (143cv)",
+      "2.0 Luxe Pack CVT (143cv)",
+      "2.0 Privilege 6MT Cuero (143cv)",
+      "2.0 Privilege CVT Cuero (143cv)",
+      "2.0T Sport 6MT (180cv)",
+      "2.0T GT2 6MT (190cv)",
+      "2.0T GT 6MT (180cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 365,
+    "modelo": "Kangoo",
+    "versiones": [
+      "II - 1.6 Authentique DA AA CD 1P",
+      "II - 1.6 Authentique Plus AA DA PK 2PLC",
+      "II - 1.6 Campus 2P",
+      "II - 1.6 Get Up DA AA CD PK 2PLC",
+      "II - 1.6 Sportway 2ABG 2PLC",
+      "II - 1.6 Authentique Plus 7as. AA DA PK 2PLC",
+      "II - 1.6 Get Up 7As. AA DA PK 2PLC",
+      "II - 1.6 Campus 2P 7as.",
+      "II - 1.6 Sportway 7as. 2ABG 2PLC",
+      "II - 1.5 dCi Authentique DA AA CD 1P",
+      "II - 1.5 dCi Authentique Plus AA DA PK 2PLC",
+      "II - 1.5 dCi Get Up DA AA CD PK 2P",
+      "II - 1.5 dCi Campus 2P",
+      "II - 1.5 dCi Sportway 2ABG 2P",
+      "II - 1.5 dCi Authentique Plus 7as. DA AA CD PK 2P",
+      "II - 1.5 dCi Authentique Plus 7as. AA PK 2PLC GPS",
+      "PH3 1.6 Authentique 1PLC",
+      "PH3 1.6 Authentique Plus 2PLC",
+      "PH3 1.6 Sportway 2PLC",
+      "PH3 1.6 Authentique Plus 7as. 2PLC"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 696,
+    "modelo": "Kangoo E-Tech",
+    "versiones": [
+      "AT (122cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 366,
+    "modelo": "Kangoo Furgón",
+    "versiones": [
+      "II - 1.6 Confort CD S/Vid.Tras 1PL",
+      "II - 1.6 Confort AA DA CD S/Vid.Tras 1PL",
+      "II - 1.6 Confort 5A DA CD CA S/Vid.Tras 2PLC",
+      "II - 1.5 dCi Génerique DA CD",
+      "II - 1.5 dCi Confort DA CD S/Vid.Tras 1P",
+      "II - 1.5 dCi Confort AA DA CD S/Vid.Tras 1P",
+      "II - 1.5 dCi Confort AA DA CD Pack Elec. 1P",
+      "II - 1.5 dCi Confort 5A CD CA DA S/Vid.Tras 2PLC",
+      "II - 1.5 dCi Grand Confort 2P",
+      "PH3 1.6 Generique",
+      "PH3 1.6 Confort 1PLC",
+      "PH3 1.6 Confort 5as. 2PLC",
+      "PH3 1.6 Confort 5as. 2PLC Pack",
+      "PH3 1.6 Gran Confort 2PLC",
+      "PH3 1.5dCi Confort AA 1PLC",
+      "PH3 1.5dCi Confort 5as. 2PLC"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 364,
+    "modelo": "Kangoo II",
+    "versiones": [
+      "1.6 SCe Life (114cv)",
+      "1.6 SCe Zen (114cv) Nav. Evolution",
+      "1.6 SCe Stepway (114cv) Nav. Evolution",
+      "1.5dCi Stepway (89cv) Nav. Evolution"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 363,
+    "modelo": "Kangoo II Express",
+    "versiones": [
+      "1.6 SCe Profesional (114cv)",
+      "1.6 SCe Confort (114cv)",
+      "1.6 SCe Confort 5As. (114cv)",
+      "1.6 SCe Emotion (114cv)",
+      "1.6 SCe Emotion 5As. (114cv)",
+      "1.5 dCi Confort (89cv)",
+      "1.5 dCi Confort 5As. (89cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 362,
+    "modelo": "Kangoo Z.E.",
+    "versiones": [
+      "Z.E",
+      "Z.E Maxi"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 695,
+    "modelo": "Kardian",
+    "versiones": [
+      "1.6 Evolution 156 MT (115cv)",
+      "1.0T Evolution 200 AT (120cv)",
+      "1.0T Techno 200 AT (120cv)",
+      "1.0T Premiere Edition 200 AT (120cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 745,
+    "modelo": "Kerax",
+    "versiones": null
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 367,
+    "modelo": "Koleos",
+    "versiones": [
+      "2.5 Zen 2WD CVT (170cv)",
+      "2.5 Intens 4WD CVT (170cv)",
+      "2.5 4x2 Expression MT PH3 (170cv)",
+      "2.5 4x2 Expression MT (170cv)",
+      "2.5 4x4 Dynamique MT S/Climat. (170cv)",
+      "2.5 4x4 Dynamique Plus MT PH3 (170cv)",
+      "2.5 4x4 Dynamique MT Climat. (170cv)",
+      "2.5 4x4 Dynamique Plus CVT PH3 (170cv)",
+      "2.5 4x4 Dynamique AT S/Climat. (170cv)",
+      "2.5 4x4 Privilege MT (170cv)",
+      "2.5 4x4 Privilege CVT PH3 (170cv)",
+      "2.5 4x4 Privilege AT (170cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 368,
+    "modelo": "Kwid",
+    "versiones": [
+      "E-Tech (65cv)",
+      "1.0 Iconic bitono MT (66cv) (L24)",
+      "1.0 Iconic Outsider MT (66cv) (L24)",
+      "1.0 Life (66cv)",
+      "1.0 Zen (66cv)",
+      "1.0 Intens (66cv)",
+      "1.0 Iconic (66cv)",
+      "1.0 Outsider (66cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 369,
+    "modelo": "Latitude",
+    "versiones": [
+      "2.0 6MT Dynamique (143cv)",
+      "3.5 V6 Privilege (240cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 370,
+    "modelo": "Logan",
+    "versiones": [
+      "II - 1.6 16v Life MT (115cv) (L20)",
+      "II - 1.6 16v Life Pack MT (115cv) (L20)",
+      "II - 1.6 16v Life Plus MT (115cv) (L20)",
+      "II - 1.6 16v Zen MT (115cv) (L20)",
+      "II - 1.6 16v Intens MT (115cv) (L20)",
+      "II - 1.6 16v Intens CVT (115cv) (L20)",
+      "II - 1.6 8v. Authentique (85cv) (L14)",
+      "II - 1.6 8v. Authentique Plus (85cv) (L14)",
+      "II - 1.6 8v. Expression (85cv) (L14)",
+      "II - 1.6 16v. Privilege (110cv) (L14)",
+      "II - 1.6 16v. Privilege Plus (110cv) (L14)",
+      "PH2 1.6 8v. Authentique Pack I (90cv) (L11)",
+      "PH2 1.6 8v. Pack (90cv) (L10)",
+      "PH2 1.6 8v. Pack I ABS ABCP (90cv) (L11)",
+      "PH2 1.6 8v. Authentique Pack II / Pack Plus (90cv) (L11)",
+      "PH2 1.6 8v. Avantage - Serie Limitada (90cv) (L11)",
+      "PH2 1.6 8v. Expression / Confort Pack I (90cv) (L11)",
+      "PH2 1.6 8v. Confort (90cv) (L10)",
+      "PH2 1.6 8v. Pack II ABS ABCP (90cv) (L11)",
+      "PH2 1.6 8v. Expression Pack I / Confort Pack II (90cv) (L11)",
+      "PH2 1.6 8v. Confort Plus (90cv) (L10)",
+      "PH2 1.6 8v. Confort II ABS (90cv) (L11)",
+      "PH2 1.5 dCi Pack (85cv) (L10)",
+      "PH2 1.5 dCi Confort (85cv) (L10)",
+      "1.6 8v. Base AA DA (90cv) (L07)",
+      "1.6 16v. Confort (105cv) (L07)",
+      "1.5 dCi Pack (85cv) (L07)",
+      "1.5 dCi Confort (85cv) (L07)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 378,
+    "modelo": "Master",
+    "versiones": [
+      "2.3 Chasis Cabina L2H1 (130cv)",
+      "2.3 Furgón L1H1 (130cv)",
+      "2.3 Furgón L1H1 Confort (130cv)",
+      "2.3 Furgón L2H2 (130cv)",
+      "2.3 Furgón L3H2  (130cv)",
+      "2.3 Minibus L2H2 ABCP ABS (130cv)",
+      "2.5 dCi Furgón Corto L1H1 Pack 1 Eléctrico / 2.8 D",
+      "2.5 dCi Furgón Corto L1H1 Pack 2 Confort (115cv)",
+      "2.5 dCi Furgón Corto Alto L1H2 Pack Eléctrico (L09) / 2.8 D",
+      "2.5 dCi Furgón Corto Alto L1H2 Pack 2 Confort (115cv)",
+      "2.5 dCi Furgón Medio AA L2H2 Pack 2 Confort / 2.8 DTI AA",
+      "2.5 dCi Furgón Largo s/vidrios L3H2 Pack 2 Confort / 2.8 DTI",
+      "2.5 dCi Chasis Cabina L2H1 Pack 2 Confort (115cv)",
+      "2.5 dCi Combi Minibus AA L2H2 Pack Full Luxury"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 371,
+    "modelo": "Megane E-Tech",
+    "versiones": [
+      "160 kW/220cv"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 372,
+    "modelo": "Mégane II",
+    "versiones": [
+      "Coupé Cabrio 2.0",
+      "4Ptas. 1.6 Confort / Expression",
+      "4Ptas. 1.6 Confort Plus / Expression Plus",
+      "4Ptas. 1.6 Luxe",
+      "4Ptas. 2.0 Luxe",
+      "4Ptas. 2.0 SL Sport (L09)",
+      "4Ptas. 2.0 SL Sport",
+      "4Ptas. 2.0 Privilege",
+      "4Ptas. 2.0 Privilege AT",
+      "4Ptas. 1.5 dCi Confort / Expression",
+      "4Ptas. 1.5 dCi Luxe",
+      "Grand Tour 1.6 Confort Plus",
+      "Grand Tour 1.6 Luxe",
+      "Grand Tour 2.0 Privilege 6MT",
+      "Grand Tour 1.5 Dci Luxe"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 373,
+    "modelo": "Mégane III",
+    "versiones": [
+      "PH2 - 1.6 Luxe Pack (110cv)",
+      "2.0 Luxe 6MT 6ABG ABS (143cv) 5Ptas.",
+      "2.0 Luxe 6MT 6ABG ABS Techo (143cv) 5Ptas.",
+      "2.0 Privilege 6MT 6ABG ABS Cuero (143cv) 5Ptas.",
+      "2.0 Privilege 6MT 6ABG ABS Cuero Techo (143cv) 5Ptas.",
+      "RS 2.0T 6MT (250cv)",
+      "RS 2.0T 6MT (265cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 743,
+    "modelo": "Midlum",
+    "versiones": null
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 360,
+    "modelo": "Oroch",
+    "versiones": [
+      "1.6 Emotion MT (114cv) (L22)",
+      "1.3T Iconic CVT (163cv) (L22)",
+      "1.3T Outsider Plus MT 4x4 (163cv) (L22)",
+      "1.6 Profesional (115cv) (L21)",
+      "1.6 Dynamique HR (115cv) (L21)",
+      "1.6 Outsider HR (115cv) (L21)",
+      "2.0 Dynamique (143cv) (L21)",
+      "2.0 Privilege (143cv) (L21)",
+      "2.0 Outsider Plus (143cv) (L21)",
+      "2.0 Dynamique 4x4 (143cv) (L21)",
+      "2.0 Outsider Plus 4x4 (143cv) (L21)",
+      "1.6 Dynamique (110cv)",
+      "1.6 Outsider (110cv)",
+      "2.0 Dynamique (143cv)",
+      "2.0 Privilege (143cv)",
+      "2.0 Outsider Plus (143cv)",
+      "2.0 Dynamique 4x4 (143cv)",
+      "2.0 Outsider Plus 4x4 (143cv)"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 744,
+    "modelo": "Premium",
+    "versiones": null
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 374,
+    "modelo": "Sandero",
+    "versiones": [
+      "II - 1.6 16v Life (115cv) (L23)",
+      "II - 1.6 16v Life Plus (115cv) (L20)",
+      "II - 1.6 16v Zen (115cv) (L20)",
+      "II - 1.6 16v Intens (115cv) (L23)",
+      "II - 1.6 16v Intens CVT (115cv) (L23)",
+      "II - 1.6 16v GT Line (105cv) (L20)",
+      "II - 1.6 16v GT Line CVT (105cv) (L20)",
+      "II - 2.0 16v RS (145cv) (L20)",
+      "II - 1.6 8v Authentique (85cv)",
+      "II - 1.6 8v Expression (85cv)",
+      "II - 1.6 8v Expression Pack (85cv)",
+      "II - 1.6 8v Dynamique (85cv)",
+      "II - 1.6 16v Privilege Nav. Evo. (105cv)",
+      "II - 1.6 16v Privilege Pack (105cv)",
+      "II - 1.6 16v GT Line (105cv)",
+      "II - 2.0 16v RS (145cv)",
+      "II - 2.0 16v RS Racing Spirit (145cv)",
+      "Fase II 1.6 8v Authentique Pack I / Pack (90cv)",
+      "Fase I 1.6 8v. Pack",
+      "Fase II 1.6 8v Authentique Pack I ABS (90cv)",
+      "Fase II 1.6 8v Authentique Pack II / Pack Plus (90cv)",
+      "Fase II 1.6 8v Expression ABS (90cv)",
+      "Fase II 1.6 16v Expression / Confort (105cv)",
+      "Fase I 1.6 16v Confort",
+      "Fase II 1.6 16v SL Tech Run (105cv)",
+      "Fase I 1.6 16v Get Up - Edic. Limitada",
+      "Fase II 1.6 16v Privilege / Luxe (105cv)",
+      "Fase I 1.6 16v Luxe",
+      "Fase II 1.6 16v Privilege NAV (105cv)",
+      "Fase II 1.6 16v GT Line (105cv)",
+      "1.5 dCi Pack",
+      "1.5 dCi Confort",
+      "1.5 dCi Luxe"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 375,
+    "modelo": "Sandero Stepway",
+    "versiones": [
+      "II - 1.6 16v Zen (115cv) (L20)",
+      "II - 1.6 16v Zen Plus (115cv) (L20)",
+      "II - 1.6 16v Intens (115cv) (L23)",
+      "II - 1.6 16v Intens CVT (115cv) (L20)",
+      "II - 1.6 16v C.A.B. (115cv) (L20)",
+      "II - 1.6 16v Expression (105cv)",
+      "II - 1.6 16v Dynamique (105cv)",
+      "II - 1.6 16v Privilege (105cv)",
+      "II - 1.6 16v Rip Curl (105cv)",
+      "II - 1.6 16v Volcom (105cv)",
+      "Fase II 1.6 16v Authentique (105cv)",
+      "Fase II 1.6 16v Expression / Confort (105cv)",
+      "Fase II 1.6 16v Expression / Confort ABCP ABS (105cv)",
+      "Fase II 1.6 16v Rip Curl (105cv)",
+      "Fase II 1.6 16v Privilege / Dynamique (105cv)",
+      "Fase II 1.6 16v Privilege Plus / Luxe (105cv)",
+      "Fase II 1.6 16v Privilege Plus NAV (105cv)",
+      "Fase II 1.6 16v SL Tweed (105cv)",
+      "1.6 16v. Confort",
+      "1.6 16v - Serie Limitada",
+      "1.6 16v. Luxe",
+      "1.5 dCi Confort"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 376,
+    "modelo": "Scénic",
+    "versiones": [
+      "1.6 Confort",
+      "1.6 Sportway S/ABS (L09)",
+      "1.9TD Confort"
+    ]
+  },
+  {
+    "marca": "RENAULT",
+    "modeloId": 377,
+    "modelo": "Symbol",
+    "versiones": [
+      "1.6 N 8v. Pack (90cv)",
+      "1.6 N 16v. Pack (105cv)",
+      "1.6 N 16v. Authentique Pack I (105cv)",
+      "1.6 N 16v. Authentique Pack II / ABS (105cv)",
+      "1.6 N 16v. Confort (105cv)",
+      "1.6 N 16v. Connection SL (105cv)",
+      "1.6 N 16v. Expression Pack II (105cv)",
+      "1.6 N 16v. Luxe (105cv)",
+      "1.5 dCi Pack (85cv)",
+      "1.5 dCi Confort (85cv)",
+      "1.5 dCi Connection (85cv)"
+    ]
+  },
+  {
+    "marca": "SEAT",
+    "modeloId": 379,
+    "modelo": "Altea",
+    "versiones": [
+      "Freetrack 2.0 TSI MT 4WD (211cv)"
+    ]
+  },
+  {
+    "marca": "SEAT",
+    "modeloId": 380,
+    "modelo": "Ibiza",
+    "versiones": [
+      "1.4 Reference (85cv) 3Ptas.",
+      "1.4 Reference (85cv) 5Ptas.",
+      "1.6 Style (105cv) 3Ptas.",
+      "1.6 Style (105cv) 5Ptas.",
+      "1.6 Sport (105cv) 3Ptas.",
+      "1.6 Sport (105cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "SEAT",
+    "modeloId": 381,
+    "modelo": "León",
+    "versiones": [
+      "1.6 MPI (102cv) (L08)",
+      "1.8 TFSI MT (160cv) (L08)",
+      "1.8 TSI DSG 7M (160cv) (L08)",
+      "2.0 TSI MT FR (211cv)",
+      "2.0 TSI MT Cupra (240cv)",
+      "2.0 TDI MT (140cv) (L07)",
+      "2.0 TDI DSG (140cv) (L07)"
+    ]
+  },
+  {
+    "marca": "SERO ELECTRIC",
+    "modeloId": 383,
+    "modelo": "Cargo",
+    "versiones": [
+      "Bajo Largo",
+      "Alto",
+      "Furgon"
+    ]
+  },
+  {
+    "marca": "SERO ELECTRIC",
+    "modeloId": 382,
+    "modelo": "Sedan",
+    "versiones": [
+      "2 Puertas",
+      "4 Pasajeros"
+    ]
+  },
+  {
+    "marca": "SHINERAY",
+    "modeloId": 384,
+    "modelo": "T30",
+    "versiones": [
+      "1.3 MT Cabina Simple (85cv)",
+      "1.3 MT Cabina Simple (85cv) Chasis y Duales"
+    ]
+  },
+  {
+    "marca": "SHINERAY",
+    "modeloId": 385,
+    "modelo": "T32",
+    "versiones": [
+      "1.3 MT Cabina Doble (85cv)",
+      "1.3 MT Cabina Doble (85cv) Chasis y Duales"
+    ]
+  },
+  {
+    "marca": "SHINERAY",
+    "modeloId": 386,
+    "modelo": "X30",
+    "versiones": [
+      "1.3 MT Furgón (85cv)",
+      "1.3 MT Furgón L (85cv)",
+      "1.3 MT Van Pasajero 7as. (85cv)"
+    ]
+  },
+  {
+    "marca": "SKYWELL",
+    "modeloId": 388,
+    "modelo": "ET5",
+    "versiones": [
+      "AT 4x2 SUV e (200cv)"
+    ]
+  },
+  {
+    "marca": "SMART",
+    "modeloId": 389,
+    "modelo": "Forfour",
+    "versiones": [
+      "1.0 City (71cv) 5Ptas.",
+      "1.0 Passion (71cv) 5Ptas.",
+      "1.0 Passion AT (71cv) 5Ptas.",
+      "1.0 Play (90cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "SMART",
+    "modeloId": 387,
+    "modelo": "Fortwo",
+    "versiones": [
+      "1.0 Coupé City (71cv)",
+      "1.0 Coupé Passion (71cv)",
+      "1.0 Coupé Play (90cv)",
+      "1.0 Coupé Sharpred Edition (84cv)",
+      "1.0 Coupé Grey Matt Edition (84cv)",
+      "1.0 Cabrio Passion (84cv)"
+    ]
+  },
+  {
+    "marca": "SOUEAST",
+    "modeloId": 390,
+    "modelo": "DX3",
+    "versiones": [
+      "1.5 MT (118cv)",
+      "1.5T CVT (156cv)"
+    ]
+  },
+  {
+    "marca": "SSANGYONG",
+    "modeloId": 391,
+    "modelo": "Actyon",
+    "versiones": [
+      "Full Equipamiento 1",
+      "Full Equipamiento 2",
+      "Full Equipamiento 3"
+    ]
+  },
+  {
+    "marca": "SSANGYONG",
+    "modeloId": 392,
+    "modelo": "Korando",
+    "versiones": [
+      "Full Equipamiento 2"
+    ]
+  },
+  {
+    "marca": "SSANGYONG",
+    "modeloId": 393,
+    "modelo": "Kyron",
+    "versiones": [
+      "Full Equipamiento 1",
+      "Full Equipamiento 2",
+      "Full Equipamiento 3"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 697,
+    "modelo": "Crosstrek",
+    "versiones": [
+      "2.0 Hybrid CVT Limited ES AWD",
+      "2.0I CVT Limited ES AWD"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 400,
+    "modelo": "Forester",
+    "versiones": [
+      "2.5 AT Turbo AWD (XT) (230cv)",
+      "2.0R X 5MT SAWD (150cv)",
+      "2.0R X 4AT Sportshift SAWD (150cv)",
+      "2.0R XS 4AT Sportshift SAWD (150cv)",
+      "2.0R XS Limited 5MT SAWD (150cv)",
+      "2.0R XS Limited 4AT Sportshift SAWD (150cv)",
+      "2.5R XT Turbo 5MT SAWD (230cv)",
+      "2.5R XT Turbo 4AT Sportshift SAWD (230cv)",
+      "2.0i AWD 6MT X (L13)",
+      "2.0i AWD CVT SI Drive XS (L13)",
+      "2.0i AWD CVT SI Drive Dynamic (L13)",
+      "2.5i AWD CVT SI Drive XS (L13)",
+      "2.5i AWD CVT SI Drive Dynamic (L13)",
+      "2.5i AWD CVT SI Drive Limited Sport (L13)",
+      "2.0XT AWD CVT SI Drive Turbo (L13)",
+      "2.0i Hybrid AWD CVT Limited EyeSight (150cv-16.7cv) (L19)",
+      "2.0i AWD CVT X (156cv) (L19)",
+      "2.0i AWD CVT XS (156cv) (L19)",
+      "2.0i AWD CVT Dynamic EyeSight (156cv) (L19)",
+      "2.0i AWD CVT Limited Sport EyeSight (156cv) (L19)",
+      "2.5i AWD CVT XS (184cv) (L19)",
+      "2.5i AWD CVT XS Dynamic EyeSight (184cv) (L19)",
+      "2.5i AWD CVT Limited Sport EyeSight (184cv) (L19)"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 394,
+    "modelo": "Impreza",
+    "versiones": [
+      "2.0 CVT Limited (156cv) (L18) 4Ptas.",
+      "2.0 CVT Dynamic (156cv) (L18) 5Ptas.",
+      "2.0 CVT Limited (156cv) (L18) 5Ptas.",
+      "1.5R MT (2A) 5Ptas. (L08)",
+      "1.5R AT (2A) 5Ptas. (L08)",
+      "2.0R MT 4x4 (NA) 4/5Ptas.",
+      "2.0R AT 4x4 (NA) 4/5Ptas.",
+      "2.0R MT 4x4 (RC) 5Ptas. (L08)",
+      "2.0R AT 4x4 (RC) 5Ptas. (L08)",
+      "2.0R MT 4x4 (RN) 4/5Ptas. (L09)",
+      "2.0R AT 4x4 (RN) 4/5Ptas. (L09)",
+      "WRX S 2.5 Turbo 5MT 4x4 5Ptas. (265cv)",
+      "WRX 265 2.5 Turbo 5MT 4x4 4/5Ptas. (265cv) (L12)",
+      "WRX STI 2.5 Turbo 6MT 4x4 4Ptas. (300cv) (L12)",
+      "WRX STI 2.5 Turbo 6MT 4x4 5Ptas. (300cv) (L08)"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 395,
+    "modelo": "Legacy",
+    "versiones": [
+      "2.5i AWD CVT (L17)",
+      "2.0i 4D AWD 6MT X (L10)",
+      "2.5i 4D AWD CVT XA (L10)",
+      "2.5i 4D AWD CVT Limited (L10)",
+      "2.5i 4D AWD CVT Sport (L10)",
+      "2.5GT 4D AWD 5AT SI Drive (L10)",
+      "2.0i AWD CVT XS Touring Wagon (L10)",
+      "2.0R 4x4 AT (150cv) 4Ptas.",
+      "3.0R AT SI-Drive Spec B SAWD (EM) (245cv)"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 396,
+    "modelo": "Outback",
+    "versiones": [
+      "2.5i AWD CVT Limited EyeSight (188cv) (L22)",
+      "2.5i AWD CVT Limited EyeSight (175cv) (L19)",
+      "3.6R AWD CVT - Limited EyeSight (L19)",
+      "2.5i AWD 6MT XS (L10)",
+      "2.5i AWD CVT XS (L10)",
+      "2.5i AWD CVT XA (L10)",
+      "2.5i AWD CVT Limited (L10)",
+      "2.5i AWD CVT Limited Tech (L10)",
+      "3.6R AWD 5AT SI Drive"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 397,
+    "modelo": "Tribeca",
+    "versiones": [
+      "3.6 AT Sportshift"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 398,
+    "modelo": "WRX",
+    "versiones": [
+      "2.4T MT Performance ES AWD (275cv)",
+      "2.0 4D AWD 6MT (270cv)",
+      "2.0 4D AWD CVT (270cv)",
+      "2.5T AWD STI"
+    ]
+  },
+  {
+    "marca": "SUBARU",
+    "modeloId": 399,
+    "modelo": "XV",
+    "versiones": [
+      "2.0i AWD CVT (L18)",
+      "2.0i AWD CVT Dynamic (L18)",
+      "2.0i AWD CVT Dynamic Eyesight (L18)",
+      "2.0i AWD CVT Limited Eyesight (L18)",
+      "2.0i AWD CVT (L16)",
+      "2.0i AWD CVT Dynamic (L16)",
+      "2.0i AWD CVT Limited (L16)",
+      "2.0 AWD 6MT (150cv) (L13)",
+      "2.0 AWD AT CVT (150cv) (L13)",
+      "2.0 AWD AT CVT Limited (150cv) (L13)",
+      "2.0R 5D AWD MT",
+      "2.0R 5D AWD AT",
+      "2.0R 5D AWD AT Limited"
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 831,
+    "modelo": "ATV",
+    "versiones": null
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 401,
+    "modelo": "Baleno",
+    "versiones": [
+      "GLX MT 1.4 MT",
+      "GLX MT 1.4 AT"
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 402,
+    "modelo": "Fun",
+    "versiones": [
+      "1.4 AA DH 3Ptas. (L07)",
+      "1.4 AA DH 5Ptas. (L07)"
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 403,
+    "modelo": "Grand Vitara",
+    "versiones": [
+      "JIII 2.0 4x4",
+      "JIII 2.4 4x4",
+      "JX 2.4L 4WD MT 3Ptas.",
+      "JLX 2.4L 2WD MT 5Ptas.",
+      "JLX-L 2.4L 4WD MT 5Ptas.",
+      "JLX-L 2.4L 4WD AT 5Ptas."
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 406,
+    "modelo": "Jimny",
+    "versiones": [
+      "1.5 GL MT (102cv)",
+      "1.5 GL MT Bitono (102cv)",
+      "1.5 GLX MT (102cv)",
+      "1.5 GLX MT Bitono (102cv)",
+      "1.5 GLX AT (102cv)",
+      "1.5 GLX AT Bitono (102cv)"
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 405,
+    "modelo": "New Vitara",
+    "versiones": [
+      "1.6 GL MT 4x2 5Ptas.",
+      "1.6 GL AT 4x2 5Ptas.",
+      "1.6 GL Plus AT 4x4 5Ptas.",
+      "1.6 GLX SR AT 4x4 5Ptas.",
+      "1.6 GLX SR AT 4x4 5Ptas. (L20)"
+    ]
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 832,
+    "modelo": "Off-Road / Adventure",
+    "versiones": null
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 835,
+    "modelo": "Scooter",
+    "versiones": null
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 833,
+    "modelo": "Street / Sport",
+    "versiones": null
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 834,
+    "modelo": "Supersport",
+    "versiones": null
+  },
+  {
+    "marca": "SUZUKI",
+    "modeloId": 404,
+    "modelo": "Swift",
+    "versiones": [
+      "1.2 CVT GLX (85cv)",
+      "1.4 MT GLX (95cv)",
+      "1.5 Nafta 5Ptas. (100cv)"
+    ]
+  },
+  {
+    "marca": "SWM",
+    "modeloId": 407,
+    "modelo": "G01",
+    "versiones": [
+      "1.5T Elite MT (154cv)",
+      "1.5T Elite AT (154cv)",
+      "1.5T Premium AT (154cv)"
+    ]
+  },
+  {
+    "marca": "SWM",
+    "modeloId": 408,
+    "modelo": "G01F",
+    "versiones": [
+      "1.5T Premium AT (154cv)"
+    ]
+  },
+  {
+    "marca": "SWM",
+    "modeloId": 409,
+    "modelo": "X7",
+    "versiones": [
+      "1.8 MT 7as. (135cv)",
+      "1.5T 6AT 7as. (154cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 410,
+    "modelo": "86",
+    "versiones": [
+      "GR MT (237cv)",
+      "FT 6MT (200cv)",
+      "GT 6MT (200cv)",
+      "GT 6AT (200cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 411,
+    "modelo": "C-HR Hybrid",
+    "versiones": [
+      "HV 1.8 e CVT (98cv-e72cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 412,
+    "modelo": "Camry",
+    "versiones": [
+      "HV 2.5 eCVT",
+      "2.5 L4 Sec. (180cv) (L18)",
+      "2.5 L4 Sec. (180cv) (L12)",
+      "2.4 L4 (167cv) (L06)",
+      "3.5 XLE 8AT V6 (302cv) (L18)",
+      "3.5 XLE Sec. V6 (277cv) (L12)",
+      "3.5 XLE Sec. V6 (277cv) (L06)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 413,
+    "modelo": "Corolla",
+    "versiones": [
+      "2.0 XLI CVT (170cv) (L23)",
+      "2.0 XEI CVT (170cv) (L23)",
+      "2.0 SEG CVT (170cv) (L23)",
+      "2.0 GR-S CVT (1710cv) (L23)",
+      "Hybrid 1.8 XEI eCVT (98cv-e72cv) (L23)",
+      "Hybrid 1.8 SEG eCVT (98cv-e72cv) (L23)",
+      "2.0 XLI MT (170cv) (L20)",
+      "2.0 XLI CVT (170cv) (L20)",
+      "2.0 XEI MT (170cv) (L20)",
+      "2.0 XEI CVT (170cv) (L20)",
+      "2.0 SEG CVT (170cv) (L20)",
+      "2.0 GR-S CVT (170cv) (L20)",
+      "Hybrid 1.8 XEI eCVT (98cv-e72cv)",
+      "Hybrid 1.8 SEG eCVT (98cv-e72cv)",
+      "XLI 1.8 MT (140cv) (L18)",
+      "XLI 1.8 MT (140cv) (L14)",
+      "XLI 1.8 MT (136cv) (L12)",
+      "XLI 1.8 MT (132cv) (L08)",
+      "XLI 1.8 CVT(140cv) (L18)",
+      "XLI 1.8 CVT (140cv) (L14)",
+      "XEI 1.8 MT (140cv) (L18)",
+      "XEI 1.8 MT (140cv) (L14)",
+      "XEI 1.8 MT (136cv) (L12)",
+      "XEI 1.8 MT (132cv) (L08)",
+      "XEI 1.8 MT Cuero (140cv) (L18)",
+      "XEI 1.8 MT Cuero (140cv) (L14)",
+      "XEI 1.8 MT Cuero (136cv) (L12)",
+      "XEI 1.8 MT Cuero (132cv) (L08)",
+      "XEI 1.8 CVT (140cv) (L18)",
+      "XEI 1.8 CVT (140cv) (L14)",
+      "XEI 1.8 AT (136cv) (L12)",
+      "XEI 1.8 AT (132cv) (L08)",
+      "XEI 1.8 CVT Cuero (140cv) (L18)",
+      "XEI 1.8 CVT Cuero (140cv) (L14)",
+      "XEI 1.8 AT Cuero (136cv) (L12)",
+      "XEI 1.8 AT Cuero (132cv) (L08)",
+      "XRS 1.8 MT (136cv) (L12)",
+      "SE-G 1.8 MT (140cv) (L18)",
+      "SE-G 1.8 MT (140cv) (L14)",
+      "SE-G 1.8 MT (136cv) (L12)",
+      "SE-G 1.8 CVT (140cv) (L18)",
+      "SE-G 1.8 CVT (140cv) (L14)",
+      "SE-G 1.8 AT (136cv) (L12)",
+      "SE-G 1.8 AT (132cv) (L08)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 414,
+    "modelo": "Corolla Cross",
+    "versiones": [
+      "HEV 1.8 XEI eCVT (L24)",
+      "HEV 1.8 SEG eCVT (L24)",
+      "2.0 XLI CVT (L24)",
+      "2.0 XEI CVT (L24)",
+      "2.0 SEG CVT (L24)",
+      "2.0 GR-S CVT (L24)",
+      "HEV 1.8 XEI eCVT (L21)",
+      "HEV 1.8 SEG eCVT (L21)",
+      "HV 1.8 XEI LE eCVT (L21)",
+      "HV 1.8 SEG eCVT (L21)",
+      "HV 1.8 SEG LE eCVT (L21)",
+      "2.0 XLI CVT (L21)",
+      "2.0 XEI CVT (L21)",
+      "2.0 SEG CVT (L21)",
+      "2.0 GR-S CVT (L21)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 698,
+    "modelo": "Crown",
+    "versiones": [
+      "2.4 HEV AT6 4WD (272cv-83cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 415,
+    "modelo": "Etios",
+    "versiones": [
+      "1.5 X 6MT (105cv) (L18) 4Ptas.",
+      "1.5 XLS 6MT (105cv) (L18) 4Ptas.",
+      "1.5 XLS Pack 6MT (105cv) (L18) 4Ptas.",
+      "1.5 XLS AT (105cv) (L18) 4Ptas.",
+      "1.5 XLS Pack AT (105cv) (L18) 4Ptas.",
+      "1.5 AIBO 6MT (105cv) (L18) 5Ptas.",
+      "1.5 X 6MT (105cv) (L18) 5Ptas.",
+      "1.5 XLS 6MT (105cv) (L18) 5Ptas.",
+      "1.5 XLS Pack 6MT (105cv) (L18) 5Ptas.",
+      "1.5 XLS AT (105cv) (L18) 5Ptas.",
+      "1.5 XLS Pack AT (105cv) (L18) 5Ptas.",
+      "1.5 X 6MT (105cv) (L16) 4Ptas.",
+      "1.5 XS 6MT (105cv) (L16) 4Ptas.",
+      "1.5 XLS 6MT (105cv) (L16) 4Ptas.",
+      "1.5 XLS AT (105cv) (L16) 4Ptas.",
+      "1.5 Platinum 6MT (105cv) (L16) 4Ptas.",
+      "1.5 Platinum AT (105cv) (L16) 4Ptas.",
+      "1.5 X 6MT (105cv) (L16) 5Ptas.",
+      "1.5 XS 6MT (105cv) (L16) 5Ptas.",
+      "1.5 XLS 6MT (105cv) (L16) 5Ptas.",
+      "1.5 XLS AT (105cv) (L16) 5Ptas.",
+      "1.5 Platinum 6MT (105cv) (L16) 5Ptas.",
+      "1.5 Platinum AT (105cv) (L16) 5Ptas.",
+      "1.5 X / X Audio (90cv) 4Ptas.",
+      "1.5 XS (90cv) 4Ptas.",
+      "1.5 XLS (90cv) 4Ptas.",
+      "1.5 Platinum (90cv) 4Ptas.",
+      "1.5 X /X Audio (90cv) 5Ptas.",
+      "1.5 XS (90cv) 5Ptas.",
+      "1.5 XLS (90cv) 5Ptas.",
+      "1.5 Platinum (90cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 416,
+    "modelo": "Etios Cross",
+    "versiones": [
+      "1.5 6MT (105cv) (L16) 5Ptas.",
+      "1.5 AT (105cv) (L16) 5Ptas.",
+      "1.5 XLS (90cv) 5Ptas"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 417,
+    "modelo": "Hiace",
+    "versiones": [
+      "Furgón 2.8 TDI 6AT 3A 5P L2H2 (L24) Nac.",
+      "Pasajero 2.8 TDI 6AT 14as. Commuter (L24) Nac.",
+      "Furgón 2.8 TDI 6AT 3A 4P L1H1",
+      "Furgón 2.8 TDI 6AT 3A 5P L2H2",
+      "Pasajero 2.8 TDI 6AT 14as. Commuter",
+      "Wagon 2.8 TDI 6AT 10as."
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 418,
+    "modelo": "Hilux",
+    "versiones": [
+      "4x2 CC DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x4 CC DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x2 CS DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x2 CD DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x2 CD DX 2.4 TDI 6AT (150cv) (L20)",
+      "4x2 CD SR 2.4 TDI 6MT (150cv) (L20)",
+      "4x2 CD SR 2.4 TDI 6AT (150cv) (L20)",
+      "4x2 CD SRV 2.8 TDI 6MT (204cv) (L20)",
+      "4x2 CD SRV 2.8 TDI 6AT (204cv) (L20)",
+      "4x2 CD SRX 2.8 TDI 6MT (204cv) (L20)",
+      "4x2 CD SRX 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CS DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x4 CD DX 2.4 TDI 6MT (150cv) (L20)",
+      "4x4 CD DX 2.4 TDI 6AT (150cv) (L20)",
+      "4x4 CD SR 2.8 TDI 6MT (204cv) (L20)",
+      "4x4 CD SR 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD SRV 2.8 TDI 6MT (204cv) (L20)",
+      "4x4 CD SRV 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD SRV+ 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD SRX 2.8 TDI 6MT 204cv) (L20)",
+      "4x4 CD SRX 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD Conquest 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD GR-S III 2.8 TDI 6AT (204cv) (L20)",
+      "4x4 CD GR-S IV 2.8 TDI 6AT (204cv) (L20)",
+      "SW4 2.8 TDI SR AT 5as. (204cv) (L20)",
+      "SW4 2.8 TDI SRX MT 7as. (204cv) (L20)",
+      "SW4 2.8 TDI SRX AT 7as. (204cv) (L20)",
+      "SW4 2.8 TDI Diamond AT 7as. (204cv) (L20)",
+      "SW4 2.8 TDI GR-S AT 7as. (224cv) (L21)",
+      "SW4 2.8 TDI GR-S AT 7as. (204cv) (L20)",
+      "4x2 CS DX 2.4 TDI 6MT (150cv) (L18)",
+      "4x2 CD DX 2.4 TDI 6MT (150cv) (L18)",
+      "4x2 CD SR 2.4 TDI 6MT (150cv) (L18)",
+      "4x2 CD SRV 2.8 TDI 6MT (177cv) (L18)",
+      "4x2 CD SRV 2.8 TDI 6AT (177cv) (L18)",
+      "4x2 CD SRX 2.8 TDI 6MT (177cv) (L18)",
+      "4x2 CD SRX 2.8 TDI 6AT (177cv) (L18)",
+      "4x4 CS DX 2.4 TDI 6MT (150cv) (L18)",
+      "4x4 CD DX 2.4 TDI 6MT (150cv) (L18)",
+      "4x4 CD SR 2.8 TDI 6MT (177cv) (L18)",
+      "4x4 CD SRV 2.8 TDI 6MT (177cv) (L18)",
+      "4x4 CD SRV 2.8 TDI 6AT (177cv) (L18)",
+      "4x4 CD SRX 2.8 TDI 6MT (177cv) (L18)",
+      "4x4 CD SRX 2.8 TDI 6AT (177cv) (L18)",
+      "4x4 CD GR-S 2.8 TDI 6MT (177cv) (L18)",
+      "4x4 CD GR-S 2.8 TDI 6AT (177cv) (L18)",
+      "4x4 CD GR-S II 4.0 V6 VVTI 6AT (238cv) (L18)",
+      "SW4 2.8 TDI SR MT 5as. (177cv) (L19)",
+      "SW4 2.8 TDI SR AT 5as. (177cv) (L19)",
+      "SW4 2.8 TDI SRX MT 7as. (177cv) (L19)",
+      "SW4 2.8 TDI SRX AT 7as. (177cv) (L19)",
+      "4x2 CS DX 2.4 TDI 6MT (150cv) (L16)",
+      "4x2 CD STD 2.4 TDI 6MT (150cv) (L16)",
+      "4x2 CD DX 2.4 TDI 6MT (150cv) (L16)",
+      "4x2 CD SR 2.4 TDI 6MT (150cv) (L16)",
+      "4x2 CD SRV 2.8 TDI 6MT (177cv) (L16)",
+      "4x2 CD SRV 2.8 TDI 6MT Pack (177cv) (L16)",
+      "4x2 CD SRV 2.8 TDI 6AT (177cv) (L16)",
+      "4x2 CD SRX 2.8 TDI 6MT (177cv) (L16)",
+      "4x2 CD SRX 2.8 TDI 6AT (177cv) (L16)",
+      "4x4 CS DX 2.4 TDI 6MT (150cv) (L16)",
+      "4x4 CD DX 2.4 TDI 6MT (150cv) (L16)",
+      "4x4 CD SR 2.8 TDI 6MT (177cv) (L16)",
+      "4x4 CD SRV 2.8 TDI 6MT (177cv) (L16)",
+      "4x4 CD SRV 2.8 TDI MT Limited (177cv) (L16)",
+      "4x4 CD SRV 2.8 TDI 6AT (177cv) (L16)",
+      "4x4 CD SRV 2.8 TDI 6AT Limited (177cv) (L16)",
+      "4x4 CD SRX 2.8 TDI 6MT (177cv) (L16)",
+      "4x4 CD SRX 2.8 TDI 6AT (177cv) (L16)",
+      "SW4 2.8 TDI SR MT 5as. (177cv) (L16)",
+      "SW4 2.8 TDI SRX MT 7as. (177cv) (L16)",
+      "SW4 2.8 TDI SRX AT 7as. (177cv) (L16)",
+      "SW4 2.8 TDI DIAMOND AT 7as. (177cv)",
+      "2.7 VVT-i C/D 4x2 SRV MT (160cv)",
+      "2.7 VVT-i C/D 4x2 SRV MT Cuero (160cv)",
+      "2.7 VVT-i C/D 4x4 SRV MT (160cv)",
+      "2.7 VVT-i C/D 4x4 SRV MT Cuero (160cv)",
+      "2.5 TDI C/S 4x2 DX (120cv)",
+      "2.5 TDI C/S 4x2 DX Pack (120cv) (L13)",
+      "2.5 TDI C/S 4x2 DX Pack Cover Cerrada (120cv) (L13)",
+      "2.5 TDI C/S 4x2 DX Cover Cerrada (120cv)",
+      "2.5 TDI C/S 4x2 DX Pack Cover Ventanas (120cv) (L13)",
+      "2.5 TDI C/S 4x2 DX Cover Ventanas (120cv)",
+      "2.5 TDI C/S 4x4 DX (120cv)",
+      "2.5 TDI C/S 4x4 DX Pack (120cv) (L13)",
+      "2.5 TDI C/S 4x4 DX Pack Cover Cerrada (120cv) (L13)",
+      "2.5 TDI C/S 4x4 DX Cover Cerrada (120cv)",
+      "2.5 TDI C/S 4x4 DX Pack Cover Ventanas (120cv) (L13)",
+      "2.5 TDI C/S 4x4 DX Cover Ventanas (120cv)",
+      "2.5 TD C/D 4x2 DX (102cv)",
+      "2.5 TDI C/D 4x2 DX Pack 2ABG ABS (120cv)",
+      "2.5 TD C/D 4x4 DX (102cv)",
+      "2.5 TDI C/D 4x4 DX Pack 2ABG ABS (120cv)",
+      "3.0 TDI C/D 4x2 SR (171cv)",
+      "3.0 TDI C/D 4x2 SRV (171cv)",
+      "3.0 TDI C/D 4x2 SRV Cuero (171cv)",
+      "3.0 TDI C/D 4x4 SR (171cv)",
+      "3.0 TDI C/D 4x4 SRV MT (171cv)",
+      "3.0 TDI C/D 4x4 SRV MT Cuero (171cv)",
+      "3.0 TDI C/D 4x4 SRV MT Limited GoPro Cuero (171cv)",
+      "3.0 TDI C/D 4x4 SRV 5AT Cuero (171cv) (L13)",
+      "3.0 TDI C/D 4x4 SRV AT Cuero (171cv)",
+      "3.0 TDI C/D 4x4 SRV AT Limited GoPro Cuero (171cv)",
+      "SW4 2.7 VVT-i 4x2 SRV AT Cuero 5as. (160cv)",
+      "SW4 2.7 VVT-i 4x2 SRV AT Cuero 7as. (160cv)",
+      "SW4 3.0 TDI SRV MT (171cv)",
+      "SW4 3.0 TDI SRV MT Cuero (171cv)",
+      "SW4 3.0 TDI SRV AT",
+      "SW4 3.0 TDI SRV 5AT Cuero (171cv) (L13)",
+      "SW4 3.0 TDI SRV AT Cuero (171cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 419,
+    "modelo": "Innova",
+    "versiones": [
+      "SR 2.7 Nafta 6AT 8As. (166cv)",
+      "SRV 2.7 Nafta 6AT 8As. (166cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 420,
+    "modelo": "Land Cruiser",
+    "versiones": [
+      "200 VX AT",
+      "300 VX AT",
+      "300 GR-S",
+      "Prado 3.0 TDI MT Techo 4ABG",
+      "Prado 3.0 TDI AT Techo 4ABG",
+      "Prado 4.0 TXL AT V6",
+      "Prado 4.0 VX MT V6",
+      "Prado 4.0 VX AT V6"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 421,
+    "modelo": "Prius",
+    "versiones": [
+      "1.8 CVT 24.5 kW/L (72cv)",
+      "1.8 N CVT / EM 60kw Hybrid Synergy Drive"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 422,
+    "modelo": "Rav 4",
+    "versiones": [
+      "2.4 4x2 AT Low (170cv) (L09)",
+      "2.4 4x2 AT Full (170cv) (L09)",
+      "2.4 4x4 AT Core (170cv) (L09)",
+      "2.4 4x4 AT Full (170cv) (L09)",
+      "2.0 TX 4x2 CVT (146cv) (L13)",
+      "2.0 VX 4x2 CVT Full (146cv) (L13)",
+      "2.5 TX 4x4 6AT (180cv) (L13)",
+      "2.5 VX 4x4 6AT Full (180cv) (L13)",
+      "HV XLE CVT FWD (218cv) (L19)",
+      "HV Limited CVT FWD (218cv) (L19)",
+      "HV Limited CVT AWD (218cv) (L19)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 423,
+    "modelo": "Supra",
+    "versiones": [
+      "GR 3.0BT AT8 (340cv)"
+    ]
+  },
+  {
+    "marca": "TOYOTA",
+    "modeloId": 424,
+    "modelo": "Yaris",
+    "versiones": [
+      "GR 1.6T MT AWD Circuit Pack (300cv) 3Ptas.",
+      "GR 1.6T AT AWD Circuit Pack (300cv) 3Ptas.",
+      "GR 1.6T MT AWD Circuit Pack (265cv) 3Ptas.",
+      "1.5 XS 6MT (107cv) 4Ptas.",
+      "1.5 XLS 6MT (107cv) 4Ptas. DISCONTINUO",
+      "1.5 XLS CVT (107cv) 4Ptas. DISCONTINUO",
+      "1.5 XLS Pack CVT (107cv) 4Ptas. DISCONTINUO",
+      "1.5 XS 6MT (107cv) 5Ptas. DISCONTINUO",
+      "1.5 XS 6MT Audio (107cv) 5Ptas.",
+      "1.5 XS CVT (107cv) 5Ptas.",
+      "1.5 XLS 6MT (107cv) 5Ptas. DISCONTINUO",
+      "1.5 XLS CVT (107cv) 5Ptas. DISCONTINUO",
+      "1.5 XLS Pack CVT (107cv) 5Ptas.",
+      "1.5 S 6MT (107cv) 5Ptas.",
+      "1.5 S CVT (107cv) 5Ptas.",
+      "1.5 16v VVT-i CVT (107cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 425,
+    "modelo": "Amarok",
+    "versiones": [
+      "2.0 TDI 4x2 C/Doble Trendline (140cv) (L24)",
+      "2.0 TDI 4x4 C/Doble Trendline (180cv) (L24)",
+      "2.0 TDI 4x2 C/Doble Comfortline (180cv) (L24)",
+      "2.0 TDI 4x2 C/Doble Comfortline AT (180cv) (L24)",
+      "2.0 TDI 4x2 C/Doble Highline (180cv) (L24)",
+      "2.0 TDI 4x2 C/Doble Highline AT (180cv) (L24)",
+      "3.0 TDI V6 C/Doble Comfortline AT8 4Motion (258cv) (L24)",
+      "3.0 TDI V6 C/Doble Highline AT8 4Motion (258cv) (L24)",
+      "3.0 TDI V6 C/Doble Extreme AT8 4Motion (258cv) (L24)",
+      "3.0 TDI V6 C/Doble Hero AT8 4Motion (258cv) (L24)",
+      "3.0 TDI V6 C/Doble Black Style AT8 4Motion (258cv) (L24)",
+      "2.0 TDI (122cv) 4x2 C/Doble Startline",
+      "2.0 TDI (122cv) 4x4 C/Doble Startline",
+      "2.0 TDI (140cv) 4x2 C/Simple Startline",
+      "2.0 TDI (140cv) 4x2 C/Simple Trendline (L17)",
+      "2.0 TDI (140cv) 4x2 C/Simple Trendline Hard Work (L17)",
+      "2.0 TDI (140cv) 4x2 C/Doble Trendline (L17)",
+      "2.0 TDI (140cv) 4x2 C/Doble Trendline LL16'' Confort & Function Hard Work (L17)",
+      "2.0 TDI (140cv) 4x4 C/Simple Startline",
+      "2.0 TDI (140cv) 4x4 C/Simple Trendline (L17)",
+      "2.0 TDI (140cv) 4x4 C/Simple Trendline Hard Work (L17)",
+      "2.0 TDI (140cv) 4x4 C/Doble Trendline (L17)",
+      "2.0 TDI (140cv) 4x4 C/Doble Trendline LL16'' Confort & Function (L17)",
+      "2.0 TDI (140cv) 4x4 C/Doble Trendline LL16'' Confort & Function Hard Work (L17)",
+      "2.0 TDI (140cv) 4x2 C/Doble Startline",
+      "2.0 TDI (140cv) 4x4 C/Doble Startline",
+      "2.0 TDI (163cv) 4x2 C/Doble Startline",
+      "2.0 TDI (163cv) 4x2 C/Doble Trendline",
+      "2.0 TDI (163cv) 4x2 C/Doble Highline",
+      "2.0 TDI (163cv) 4x2 C/Doble Highline Pack",
+      "2.0 TDI (163cv) 4x4 C/Doble Startline",
+      "2.0 TDI (163cv) 4x4 C/Doble Trendline",
+      "2.0 TDI (163cv) 4x4 C/Doble Highline",
+      "2.0 TDI (163cv) 4x4 C/Doble Highline Pack",
+      "2.0 TDI (163cv) 4x4 C/Doble Highline Black",
+      "2.0 TDI (180cv) 4x2 C/Doble Startline",
+      "2.0 TDI (180cv) 4x2 C/Doble Trendline",
+      "2.0 TDI (180cv) 4x2 C/Doble Trendline AT",
+      "2.0 TDI (180cv) 4x2 C/Doble Comfortline (L17)",
+      "2.0 TDI (180cv) 4x2 C/Doble Comfortline AT (L17)",
+      "2.0 TDI (180cv) 4x2 C/Doble Dark Label",
+      "2.0 TDI (180cv) 4x2 C/Doble Dark Label AT",
+      "2.0 TDI (180cv) 4x2 C/Doble Highline (L17)",
+      "2.0 TDI (180cv) 4x2 C/Doble Highline",
+      "2.0 TDI (180cv) 4x2 C/Doble Highline AT (L17)",
+      "2.0 TDI (180cv) 4x2 C/Doble Highline Pack",
+      "2.0 TDI (180cv) 4x2 C/Doble Highline Pack AT",
+      "2.0 TDI (180cv) 4x2 C/Doble Ultimate",
+      "2.0 TDI (180cv) 4x2 C/Doble Ultimate AT",
+      "2.0 TDI (180cv) 4x4 C/Doble Startline",
+      "2.0 TDI (180cv) 4x4 C/Doble Trendline",
+      "2.0 TDI (180cv) 4x4 C/Doble Trendline AT",
+      "2.0 TDI (180cv) 4x4 C/Doble Comfortline (L17)",
+      "2.0 TDI (180cv) 4x4 C/Doble Comfortline AT (L17)",
+      "2.0 TDI (180cv) 4x4 C/Doble Dark Label",
+      "2.0 TDI (180cv) 4x4 C/Doble Dark Label AT",
+      "2.0 TDI (180cv) 4x4 C/Doble Black Edition",
+      "2.0 TDI (180cv) 4x4 C/Doble Black Edition AT",
+      "2.0 TDI (180cv) 4x4 C/Doble Highline (L17)",
+      "2.0 TDI (180cv) 4x4 C/Doble Highline",
+      "2.0 TDI (180cv) 4x4 C/Doble Highline Pack",
+      "2.0 TDI (180cv) 4x4 C/Doble Highline AT (L17)",
+      "2.0 TDI (180cv) 4x4 C/Doble Highline Pack AT",
+      "2.0 TDI (180cv) 4x4 C/Doble Ultimate",
+      "2.0 TDI (180cv) 4x4 C/Doble Ultimate AT",
+      "3.0 TDI V6 (258cv) 4x4 C/Doble Comfortline AT",
+      "3.0 TDI V6 (258cv) 4x4 C/Doble Highline P1 AT",
+      "3.0 TDI V6 (258cv) 4x4 C/Doble Highline AT",
+      "3.0 TDI V6 (258cv) 4x4 C/Doble Extreme AT",
+      "3.0 TDI V6 (258cv) 4x4 C/Doble Black Style AT",
+      "3.0 TDI V6 (224cv) 4x4 C/Doble Comfortline AT (L17)",
+      "3.0 TDI V6 (224cv) 4x4 C/Doble Highline AT (L17)",
+      "3.0 TDI V6 (224cv) 4x4 C/Doble Extreme AT (L17)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 426,
+    "modelo": "Bora",
+    "versiones": [
+      "1.8T Highline MT",
+      "1.8T Highline MT Cuero",
+      "1.8T Highline Tiptronic",
+      "1.8T Highline Tiptronic Cuero",
+      "2.0 Trendline MT",
+      "2.0 Trendline Tiptronic",
+      "1.9 TDI Trendline"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 757,
+    "modelo": "Buses",
+    "versiones": null
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 756,
+    "modelo": "Camiones",
+    "versiones": null
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 437,
+    "modelo": "CC",
+    "versiones": [
+      "2.0 TSI MT Advance (211cv)",
+      "2.0 TSI MT Luxury (211cv)",
+      "2.0 TSI MT Exclusive (211cv)",
+      "2.0 TSI DSG Advance (211cv)",
+      "2.0 TSI DSG Luxury (211cv)",
+      "2.0 TSI DSG Exclusive (211cv)",
+      "2.0 TSI DSG Elegance (211cv)",
+      "2.0 TDI MT Advance (170cv)",
+      "2.0 TDI MT Luxury (170cv)",
+      "2.0 TDI MT Exclusive (170cv)",
+      "2.0 TDI DSG Advance (170cv)",
+      "2.0 TDI DSG Luxury (170cv)",
+      "2.0 TDI DSG Exclusive (170cv)",
+      "3.6 V6 DSG 4Motion Highline (300cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 427,
+    "modelo": "CrossFox",
+    "versiones": [
+      "1.6 Comfortline 5Ptas. (MY14 ABG ABS)",
+      "1.6 Trendline 5Ptas. (MY14 ABG ABS)",
+      "1.6 Trendline Cuero 5Ptas.",
+      "1.6 Highline 5Ptas. (ABG ABS)",
+      "1.6 Highline Cuero 5Ptas. (MY14 ABG ABS)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 428,
+    "modelo": "Fox",
+    "versiones": [
+      "1.6 MSI Comfortline 5Ptas. (101cv) (L15)",
+      "1.6 MSI Track 5Ptas. (101cv) (L15)",
+      "1.6 MSI Trendline 5Ptas. (101cv) (L15)",
+      "1.6 MSI Connect 5Ptas. (101cv) (L15)",
+      "1.6 MSI 16V Highline 5Ptas. (110cv) (L15)",
+      "1.6 MSI 16V Highline I-Motion 5Ptas. (110cv) (L15)",
+      "1.6 MSI Pepper 5Ptas. (101cv) (L15)",
+      "1.6 Comfortline 3Ptas. (MY14 ABG ABS)",
+      "1.6 Comfortline Pack 3Ptas. (MY14 ABG ABS)",
+      "1.6 Trendline 3Ptas. (MY14 ABG ABS)",
+      "1.6 Sportline 3Ptas.",
+      "1.6 Route 3Ptas.",
+      "1.6 Highline 3Ptas. (MY14 ABG ABS)",
+      "1.6 Comfortline 5Ptas. (MY14 ABG ABS)",
+      "1.6 Comfortline Pack 5Ptas. (MY14 ABG ABS)",
+      "1.6 Trendline 5Ptas. (MY14 ABG ABS)",
+      "1.6 Trendline I-Motion 5Ptas.",
+      "1.6 Highline 5Ptas. (MY14 ABG ABS)",
+      "1.6 Highline I-Motion 5Ptas. (MY14 ABG ABS)",
+      "1.9 SDI Comfortline 5Ptas. (Faros)",
+      "1.9 SDI Trendline 5Ptas. (Faros / PM / Spoiler)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 429,
+    "modelo": "Gol",
+    "versiones": [
+      "1.4 3Ptas. Power (83cv)",
+      "1.4 3Ptas. Power AA DA (83cv)",
+      "1.4 5Ptas. Power (83cv)",
+      "1.4 5Ptas. Power AA DA (83cv)",
+      "Country 1.4 Power Base (83cv)",
+      "Country 1.4 Power AA DA (83cv)",
+      "1.6 3Ptas. Power",
+      "1.6 3Ptas. Power AA DA",
+      "1.6 3Ptas. LOOk",
+      "1.6 3Ptas. Trendline Plus",
+      "1.6 5Ptas. Power",
+      "1.6 5Ptas. Power AA DA",
+      "1.6 5Ptas. LOOk",
+      "1.6 5Ptas. Comfortline",
+      "1.6 5Ptas. Trendline Plus",
+      "1.9 SD 3Ptas. Power / Plus",
+      "1.9 SD 3Ptas. Power AA DA",
+      "1.9 SD 3Ptas. Comfortline",
+      "1.9 SD 3Ptas. Trendline Plus",
+      "1.9 SD 5Ptas. Format",
+      "1.9 SD 5Ptas. Power / Plus",
+      "1.9 SD 5Ptas. Power AA DA",
+      "1.9 SD 5Ptas. Comfortline",
+      "1.9 SD 5Ptas. Trendline Plus",
+      "Country 1.6 Format",
+      "Country 1.6 Power AA DA",
+      "Country 1.6 Comfortline Plus 2ABG",
+      "Country 1.6 Trendline Plus 2ABG",
+      "Country 1.9 SD Power (Int.Plus AA DA)",
+      "Country 1.9 SD Comfortline AA",
+      "Country 1.9 SD Comfortline Plus 2ABG",
+      "Country 1.9 SD Trendline Plus 2ABG"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 430,
+    "modelo": "Gol Trend",
+    "versiones": [
+      "1.6 MSI 3Ptas. Serie (101cv) (L17)",
+      "1.6 MSI 3Ptas. Trendline (101cv) (L17)",
+      "1.6 MSI 5Ptas. Serie (101cv) (L17)",
+      "1.6 MSI 5Ptas. Trendline (101cv) (L19)",
+      "1.6 MSI 5Ptas. Trendline (101cv) (L17)",
+      "1.6 MSI 5Ptas. Trendline AT (101cv) (L19)",
+      "1.6 MSI 5Ptas. Sportline (101cv) (L17)",
+      "1.6 MSI 5Ptas. Comfortline (101cv) (L19)",
+      "1.6 MSI 5Ptas. Comfortline (101cv) (L17)",
+      "1.6 MSI 5Ptas. Comfortline Tiptronic (101cv) (L19)",
+      "1.6 MSI 5Ptas. Connect (101cv) (L17)",
+      "1.6 MSI 5Ptas. Highline (101cv) (L17)",
+      "1.6 MSI 5Ptas. Highline I-Motion (101cv) (L17)",
+      "1.6 3Ptas. Base / Serie (101cv)",
+      "1.6 3Ptas. Startline I (101cv)",
+      "1.6 3Ptas. Trendline / Pack I (101cv)",
+      "1.6 3Ptas. Pack II (101cv) (MY14 ABG ABS)",
+      "1.6 3Ptas. Highline / Pack III (101cv)",
+      "1.6 5Ptas. Base / Serie (101cv)",
+      "1.6 5Ptas. Startline I (101cv)",
+      "1.6 5Ptas. Trendline / Pack I (101cv)",
+      "1.6 5Ptas. Pack I Plus I-Motion (101cv)",
+      "1.6 5Ptas. Pack II (101cv)",
+      "1.6 5Ptas. Cup (101cv)",
+      "1.6 5Ptas. Sportline (101cv)",
+      "1.6 5Ptas. Highline / Pack III (101cv)",
+      "1.6 5Ptas. Highline I-Motion / Pack III (101cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 431,
+    "modelo": "Golf",
+    "versiones": [
+      "1.6 Trendline MT (110cv) (L17)",
+      "1.4 TSI Comfortline MT (150cv) (L17)",
+      "1.4 TSI Comfortline DSG (150cv) (L17)",
+      "1.4 TSI Highline DSG (150cv) (L17)",
+      "1.4 TSI Highline 250 DSG (150cv)",
+      "Variant 1.6 Trendline MT (110cv) (L17)",
+      "Variant 1.4 TSI Comfortline MT (150cv) (L17)",
+      "Variant 1.4 TSI Comfortline DSG (150cv) (L17)",
+      "Variant 1.4 TSI Highline DSG (150cv) (L17)",
+      "GTI 2.0 TSI DSG (230cv) (17)",
+      "GTI 2.0 TSI DSG Cuero (230cv)",
+      "1.4 TSI Comfortline MT (150cv) (L15)",
+      "1.4 TSI Comfortline DSG (150cv) (L15)",
+      "1.4 TSI Highline DSG (150cv) (L15)",
+      "1.6 Trendline MT (110cv) (L15)",
+      "2.0 GTI DSG (220cv) (L15)",
+      "2.0 GTI DSG App Connect Cuero (220cv) (L15)",
+      "Variant 1.4 TSI Comfortline MT (150cv) (L15)",
+      "Variant 1.4 TSI Comfortline DSG(150cv) (L15)",
+      "Variant 1.4 TSI Highline DSG (150cv) (L15)",
+      "Variant 1.6 MT Trendline (110cv) (L15)",
+      "Variant 1.6 Tiptronic Trendline (110cv) (L15)",
+      "1.6 Format (100cv) (L07)",
+      "1.6 Conceptline / Comfortline (100cv) (L07)",
+      "1.6 Advance (100cv) (L07)",
+      "2.0 Advance (116cv)",
+      "2.0 Advance Tiptronic (116cv)",
+      "2.0 Highline MT (116cv)",
+      "2.0 Highline Tiptronic (116cv) (L07)",
+      "GTI 1.8T MT Cuero 5Ptas. (180cv)",
+      "GTI 1.8T Tiptronic Cuero 5Ptas. (180cv)",
+      "GTI 2.0T MT (211cv) 5Ptas.",
+      "GTI 2.0T MT NAV (211cv) 5Ptas.",
+      "GTI 2.0T DSG (211cv) 5Ptas.",
+      "GTI 2.0T DSG NAV (211cv) 5Ptas.",
+      "1.9 TDI Advance (90cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 432,
+    "modelo": "Multivan",
+    "versiones": [
+      "1.9 TDI Comfortline (105cv)",
+      "2.5 TDI Highline (175cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 434,
+    "modelo": "New Beetle",
+    "versiones": [
+      "1.8T Sport",
+      "1.8T Sport Tiptronic",
+      "2.0 MT Advance",
+      "2.0 Tiptronic Advance",
+      "2.0 MT Luxury",
+      "2.0 Tiptronic Luxury",
+      "2.5 Sport",
+      "2.5 Sport Tiptronic",
+      "1.8T Cabrio Sport",
+      "2.5 Cabrio Sport",
+      "2.5 Cabrio Sport Tiptronic"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 435,
+    "modelo": "Nivus",
+    "versiones": [
+      "170TSi MT (101cv) (L25)",
+      "Trendline 200TSI Tiptronic (116cv) (L25)",
+      "Comfortline 200TSI Tiptronic (116cv) (L25)",
+      "Highline 200TSI Tiptronic (116cv) (L25)",
+      "Outfit 200TSI Tiptronic (116cv) (L25)",
+      "170 1.0TSI MT (95cv) DISCONTINUO",
+      "Comfortline 200 1.0TSI Tiptronic (116cv) DISCONTINUO",
+      "Highline 200 1.0TSI Tiptronic (116cv) DISCONTINUO",
+      "Highline Hero 200 1.0TSI Tiptronic (116cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 436,
+    "modelo": "Passat",
+    "versiones": [
+      "1.8 TSi Comfort MT (160cv) (L11)",
+      "1.8 TSi Comfort DSG (160cv) (L11)",
+      "2.0 TSi Advance MT (211cv) (L11)",
+      "2.0 TSI Advance MT (200cv)",
+      "2.0 FSI Advance MT (150cv)",
+      "2.0 TSi Advance DSG (211cv) (L11)",
+      "2.0 TSI Advance DSG (200cv)",
+      "2.0T FSI Advance Tiptronic (200cv)",
+      "2.0 TSi Luxury MT (200cv) (L11)",
+      "2.0 TSI Luxury MT (200cv)",
+      "2.0 FSI Luxury MT (150cv)",
+      "2.0 TSi Luxury DSG (200cv) (L11)",
+      "2.0 TSI Luxury DSG (200cv)",
+      "2.0T FSI Luxury Tiptronic (200cv)",
+      "2.0 TSI Exclusive MT (200cv)",
+      "2.0 FSI Exclusive MT (150cv)",
+      "2.0 TSI Exclusive DSG (200cv)",
+      "2.0T FSI Exclusive Tiptronic (200cv)",
+      "2.0 TSI Highline DSG (220cv) (L17)",
+      "2.0 TSI R-Line DSG (220cv) (L17)",
+      "2.0 TDI BlueMotion Advance MT (170cv)",
+      "2.0 TDI Advance MT (140cv)",
+      "2.0 TDi BlueMotion Advance DSG (170cv)",
+      "2.0 TDI Advance DSG (140cv)",
+      "2.0 TDI BlueMotion Luxury MT (170cv)",
+      "2.0 TDI Luxury MT (140cv)",
+      "2.0 TDI BlueMotion Luxury DSG (170cv)",
+      "2.0 TDI Luxury DSG (140cv)",
+      "2.0 TDI Exclusive MT (140cv)",
+      "2.0 TDI Exclusive DSG (140cv)",
+      "2.0 TDI 4Motion Advance (140cv)",
+      "2.0 TDI 4Motion Luxury (140cv)",
+      "2.0 TDI 4Motion Exclusive (140cv)",
+      "3.2 FSI V6 DSG Highline / Highline Wood",
+      "Variant 2.0 TFSI Advance MT (200cv)",
+      "Variant 2.0 TFSI Advance DSG (200cv)",
+      "Variant 2.0 TFSI Advance Tiptronic (200cv)",
+      "Variant 2.0 TFSI Elegance MT (200cv)",
+      "Variant 2.0 TFSI Elegance DSG (200cv)",
+      "Variant 2.0 TFSI Elegance Tiptronic (200cv)",
+      "Variant 2.0 TSi Luxury MT Techo(211cv) (L11)",
+      "Variant 2.0 TSi Luxury DSG Techo (211cv) (L11)",
+      "Variant 2.0 TDI Advance MT (170cv) (L11)",
+      "Variant 2.0 TDI Advance MT (140cv)",
+      "Variant 2.0 TDI Advance DSG (170cv) (L11)",
+      "Variant 2.0 TDI Advance DSG / Tiptronic (140cv)",
+      "Variant 2.0 TDI Luxury MT (140cv)",
+      "Variant 2.0 TDI Luxury DSG / Tiptronic (140cv)",
+      "Variant 2.0 TDI Elegance MT (140cv)",
+      "Variant 2.0 TDI Elegance DSG / Tiptronic (140cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 438,
+    "modelo": "Polo",
+    "versiones": [
+      "1.6 MSi Track MT 5Ptas. (110cv) (L23)",
+      "1.6 MSi Track 1st.Edition MT 5Ptas. (110cv) (L23)",
+      "1.6 MSi MT 5Ptas. (110cv) (L23) DISCONTINUO",
+      "1.0TSi 170 Comfortline AT 5Ptas. (101cv) (L23)",
+      "1.0TSi 170 Highline AT 5Ptas. (101cv) (L23)",
+      "1.4 TSi GTS Tiptronic (150cv) (L23)",
+      "1.4 TSi GTS Tiptronic (150cv)",
+      "1.6 MSi Trend MT (110cv) (L18) 5Ptas.",
+      "1.6 MSi MT (110cv) 5Ptas.",
+      "1.6 MSi AT (110cv) 5Ptas",
+      "1.6 MSi Trendline MT (110cv) (L18) 5Ptas.",
+      "1.6 MSi Trendline Tiptronic (110cv) (L18) 5Ptas.",
+      "1.6 MSi Comfortline MT (110cv) (L18) 5Ptas.",
+      "1.6 MSi Comfortline Plus Tiptronic (110cv) (L18) 5Ptas.",
+      "1.6 MSi Highline MT (110cv) (L18) 5Ptas.",
+      "1.6 MSi Highline Tiptronic (110cv) (L18) 5Ptas.",
+      "1.6 Comfortline MT (105cv) (L15) 4Ptas.",
+      "1.6 Comfortline Tiptronic (105cv) (L15) 4Ptas.",
+      "Classic 1.6 Format",
+      "Classic 1.6 Comfortline",
+      "Classic 1.6 Trendline",
+      "Classic 1.9 SD Format",
+      "Classic 1.9 SD Comfortline",
+      "Classic 1.9 SD Trendline",
+      "Classic 1.9 TDI Highline ABS AB TC"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 439,
+    "modelo": "Saveiro",
+    "versiones": [
+      "1.6 MSI Cabina Simple Trendline (110cv) (L24)",
+      "1.6 MSI Cabina Doble Comfortline (110cv) (L24)",
+      "1.6 MSI Cabina Doble Extreme (110cv) (L24)",
+      "1.6 MSI Cabina Simple Trendline (101cv) (L21)",
+      "1.6 MSI Cabina Extendida Comfortline (101cv) (L18)",
+      "1.6 MSI Cabina Doble Comfortline (101cv) (L21)",
+      "1.6 MSI Cabina Doble Highline (101cv) (L21)",
+      "1.6 MSI Cross Cabina Doble (101cv) (L21)",
+      "1.6 MSI Cabina Simple Safety (101cv) (L16)",
+      "1.6 MSI Cabina Extendida Safety (101cv) (L16)",
+      "1.6 MSI Cabina Extendida Pack High (101cv) (L16)",
+      "1.6 MSI Cabina Doble Power (101cv) (L16)",
+      "1.6 MSI Cabina Doble Pack High (101cv) (L16)",
+      "1.6 MSI Cross Cabina Doble (110cv) (L16)",
+      "Cabina Simple 1.6 Serie (101cv) (L13)",
+      "Cabina Simple 1.6 Safety / Pack (101cv) (L13)",
+      "Cabina Extendida 1.6 Safety Pack Elec.(101cv) (L13)",
+      "Cabina Extendida 1.6 N Pack High / Pack Elec. + Seg. (101cv) (L13)",
+      "Cabina Doble 1.6 Power (101cv) (L13)",
+      "Cabina Doble 1.6 Pack High (101cv) (L13)",
+      "Cross Cabina Doble 1.6 ESP ASR EDS (110cv)",
+      "1.6 Mi",
+      "1.6 Mi AA",
+      "1.9 SD DH",
+      "1.9 SD DH AA"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 440,
+    "modelo": "Scirocco",
+    "versiones": [
+      "1.4 TSI MT (160cv)",
+      "1.4 TSI DSG (160cv)",
+      "2.0 TSI MT (211cv)",
+      "2.0 TSI DSG (211cv)",
+      "2.0 TSI DSG GTS (211cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 441,
+    "modelo": "Sharan",
+    "versiones": [
+      "1.4 TSi 6MT Bluemotion Comfortline (150cv)",
+      "2.0 TSi DSG Highline (200cv)",
+      "1.8 T Trendline",
+      "1.8 T Trendline Tiptronic",
+      "1.8 T Trendline Tiptronic Cuero 2Climat.",
+      "1.9 TDI Highline",
+      "1.9 TDI Highline Cuero 2Climat.",
+      "1.9 TDI Highline Tiptronic",
+      "1.9 TDI Highline Tiptronic Cuero",
+      "1.9 TDI Highline Tiptronic Cuero 2Climat."
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 442,
+    "modelo": "Suran",
+    "versiones": [
+      "1.6 MSI Comfortline (L15)",
+      "1.6 MSI Trendline (L15)",
+      "1.6 MSI Highline (L15)",
+      "1.6 MSI Highline Cuero (L15)",
+      "1.6 MSI Highline Navi Cuero / Techo (L15)",
+      "1.6 MSI Highline I-Motion (L15)",
+      "1.6 MSI Highline I-Motion Techo (L15)",
+      "1.6 MSI Highline I-Motion Navi Techo Cuero (L15)",
+      "Track 1.6 MSI (L15)",
+      "Cross 1.6 MSI Highline MT (L15)",
+      "Cross 1.6 MSI Highline MT Cuero (L18)",
+      "Cross 1.6 Highline s/cuero (101cv) (MY14 ABG ABS)",
+      "1.6 Comfortline / Style (MY14 ABG ABS)",
+      "1.6 Trendline (MY14 ABG ABS)",
+      "1.6 Trendline I-Motion",
+      "1.6 Limited",
+      "1.6 Highline (MY14 ABG ABS)",
+      "1.6 Highline Cuero (MY14 ABG ABS)",
+      "1.6 Highline I-Motion (MY14 ABG ABS)",
+      "1.6 Highline I-Motion Cuero",
+      "1.9 SDI Comfortline",
+      "1.9 SDI Trendline",
+      "1.9 SDI Highline",
+      "1.9 SDI Highline Cuero"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 443,
+    "modelo": "T-Cross",
+    "versiones": [
+      "170 TSI Trendline MT (101cv)",
+      "200 TSI Trendline Tiptronic (116cv)",
+      "200 TSI Comfortline Tiptronic (116cv)",
+      "200 TSI Highline Tiptronic (116cv)",
+      "200 TSI Highline Tiptronic Bi-Tono (116cv)",
+      "1.6 MSI Trendline (110cv)",
+      "1.6 MSI Comfortline MT (110cv)",
+      "1.6 MSI Comfortline Tiptronic (110cv)",
+      "1.6 MSI Highline Tiptronic (110cv)",
+      "1.6 MSI Hero Tiptronic (110cv)",
+      "1.6 MSI Style Edition Tiptronic (110cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 444,
+    "modelo": "Taos",
+    "versiones": [
+      "Comfortline 250TSI Tiptronic (150cv)",
+      "Highline 250TSI Tiptronic (150cv)",
+      "Highline 250TSI Tiptronic Bitono (150cv)",
+      "Hero 250TSI Tiptronic (150cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 433,
+    "modelo": "The Beetle",
+    "versiones": [
+      "1.4 TSI Design MT (L17)",
+      "1.4 TSI Design DSG (L17)",
+      "2.0 TSI Sport MT (L14)",
+      "2.0 TSI Sport DSG (L17)",
+      "2.0 TSI Sport Cabrio MT (L14)",
+      "2.0 TSI Sport Cabrio DSG (L17)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 445,
+    "modelo": "Tiguan",
+    "versiones": [
+      "2.0 TSI Sport & Style Tiptronic (L16)",
+      "2.0 TSI Premium Tiptronic (L16)",
+      "2.0 TSI Sport & Style MT (L11)",
+      "2.0 TSI Sport & Style Tiptronic (L11)",
+      "2.0 TSI Exclusive MT (L11)",
+      "2.0 TSI Exclusive Tiptronic (L11)",
+      "2.0 TSI Elegance (L11)",
+      "2.0 TSI Elegance Tiptronic (L11)",
+      "2.0 TSI Premium MT (L11)",
+      "2.0 TSI Premium Tiptronic (L11)",
+      "2.0 TDI Sport & Style Tiptronic (L11)",
+      "2.0 TDI Exclusive Tiptronic (L11)",
+      "2.0 TDI Elegance Tiptronic (L11)",
+      "2.0 TDI Premium Tiptronic (L11)",
+      "2.0 TSI MT Sport Plus / Sport & Style (L08)",
+      "2.0 TSI AT Sport Plus / Sport & Style (L08)",
+      "2.0 TSI MT Sport Plus II / Exclusive (L08)",
+      "2.0 TSI AT Sport Plus II / Exclusive (L08)",
+      "2.0 TDI AT Sport Plus / Sport & Style (L08)",
+      "2.0 TDI AT Sport Plus II / Exclusive (L08)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 446,
+    "modelo": "Tiguan Allspace",
+    "versiones": [
+      "1.4 TSi 250 DSG (150cv)",
+      "2.0 TSi 350 Life DSG 4Motion (220cv)",
+      "2.0 TSi 350 Comfortline DSG 4Motion (220cv)",
+      "2.0 TSi 350 Highline DSG 4Motion (220cv)",
+      "1.4 TSi Trendline DSG (150cv)",
+      "2.0 TSi Comfortline DSG 4Motion (220cv)",
+      "2.0 TSi Comfortline DSG 4Motion Techo Panor. (220cv)",
+      "2.0 TSi Highline DSG 4Motion (220cv)",
+      "2.0 TDI Highline DSG 4Motion (220cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 447,
+    "modelo": "Touareg",
+    "versiones": [
+      "HYBRID 3.0 FSI DSG V6 (379cv)",
+      "3.6 FSI V6 Life (280cv) (L11)",
+      "3.6 FSI V6 Style (280cv) (L11)",
+      "3.6 FSI V6 Elegance (280cv) (L11)",
+      "4.2 FSI V8 Premium Tiptronic (350cv) (L11)",
+      "4.2 FSI V8 Premium Tiptronic (360cv) (L16)",
+      "3.0 TDI V6 Life (204cv) (L11)",
+      "3.0 TDI V6 Style (204cv) (L11)",
+      "3.0 TDI V6 Elegance (204cv) (L11)",
+      "3.0 TDI V6 Tiptronic (258cv) (L20)",
+      "3.0 TDI V6 Premium Tiptronic (245cv) (L16)",
+      "2.5 TDI R5 Style",
+      "2.5 TDI R5 Premium (174cv)",
+      "3.6 V6 Style (280cv)",
+      "3.6 V6 Premium (280cv)",
+      "4.2 V8 Premium (350cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 448,
+    "modelo": "Transporter",
+    "versiones": [
+      "1.9 TDI (105cv)",
+      "1.9 TDI doble hoja (105cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 449,
+    "modelo": "Up",
+    "versiones": [
+      "1.0 Take Up! AA (75cv) 5Ptas. (L19)",
+      "1.0 Move Up! (75cv) 5Ptas. (L19)",
+      "1.0 High Up! (75cv) 5Ptas. (L19)",
+      "1.0 Tsi Pepper Up! (101cv) 5Ptas. (L19)",
+      "CROSS Up! 1.0 Tsi (101cv) 5Ptas. (L19)",
+      "1.0 Take Up! (75cv) 3Ptas.",
+      "1.0 Take Up! AA (75cv) 3Ptas.",
+      "1.0 Move Up! (75cv) 3Ptas.",
+      "1.0 High Up! (75cv) 3Ptas.",
+      "1.0 Take Up! AA (75cv) 5Ptas.",
+      "1.0 Move Up! (75cv) 5Ptas.",
+      "1.0 Move Up! I-Motion (75cv) 5Ptas.",
+      "1.0 High Up! (75cv) 5Ptas.",
+      "1.0 High Up! I-Motion (75cv) 5Ptas.",
+      "1.0 Black Up (75cv) 5Ptas.",
+      "1.0 White Up! (75cv) 5Ptas.",
+      "CROSS 1.0 (75cv) 5Ptas."
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 450,
+    "modelo": "Vento",
+    "versiones": [
+      "2.0 Advance MT 8v. (115cv) (L11)",
+      "2.0 Advance MT Summer Pack (115cv) (L11)",
+      "2.0 TSi GLI MT (211cv) (L16)",
+      "2.0 TSi GLI MT NAV (211cv) (L16)",
+      "2.0 TSi GLI DSG (211cv) (L16)",
+      "2.0 TSi GLI DSG NAV (211cv) (L16)",
+      "2.0 TSI GLI DSG (230cv) (L19)",
+      "350TSI GLI 2.0 DSG (231cv) (L25)",
+      "350TSI GLI 2.0 DSG (231cv) (L23)",
+      "1.4 TSI MT Comfortline (150cv)",
+      "1.4 TSI AT Comfortline (150cv) (L19)",
+      "1.4 TSI DSG Comfortline (150cv)",
+      "1.4 TSI MT Highline (150cv)",
+      "1.4 TSI AT Highline (150cv) (L19)",
+      "1.4 TSI AT Highline 250 (150cv)",
+      "1.4 TSI DSG Highline (150cv)",
+      "2.0 TSi Sportline MT (211cv) (L11)",
+      "2.0 TFSI Sportline MT (200cv)",
+      "2.0 TSi Sportline DSG (211cv) (L11)",
+      "2.0 TFSI Sportline DSG (200cv)",
+      "2.0 TFSI Elegance MT (200cv)",
+      "2.0 TFSI Elegance DSG (200cv)",
+      "2.5 R5 Advance MT (170cv)",
+      "2.5 R5 Advance Tiptronic (170cv)",
+      "2.5 R5 Advance Plus MT (170cv)",
+      "2.5 R5 Advance Plus Tiptronic (170cv)",
+      "2.5 R5 Luxury MT (170cv) (L11)",
+      "2.5 R5 Luxury Wood MT (170cv)",
+      "2.5 R5 Luxury Tiptronic (170cv) (L11)",
+      "2.5 R5 Luxury Wood Tiptronic (170cv)",
+      "1.9 TDI Advance MT (105cv)",
+      "1.9 TDI Advance DSG / Tiptronic (105cv)",
+      "1.9 TDI Luxury Wood MT (105cv)",
+      "1.9 TDI Luxury Wood DSG / Tiptronic (105cv)",
+      "2.0 TDI Comfortline MT (110cv) (L11)",
+      "2.0 TDI Advance MT (110cv) (L11)",
+      "2.0 TDI Luxury MT (140cv) (L11)",
+      "2.0 TDI Luxury DSG (140cv) (L11)",
+      "2.0 TDI Sportline MT (140cv)",
+      "2.0 TDI Sportline DSG (140cv)",
+      "2.0 TDI Elegance MT (140cv)",
+      "2.0 TDI Elegance DSG (140cv)",
+      "Variant 2.5 R5 Confort MT (170cv) (L11)",
+      "Variant 2.5 R5 Advance MT (170cv) (L11)",
+      "Variant 2.5 R5 Advance Tiptronic (170cv)",
+      "Variant 1.9 TDI Advance MT (105cv)",
+      "Variant 1.9 TDI Advance DSG (105cv)",
+      "Variant 2.0 TDI Confort MT (110cv) (L11)",
+      "Variant 2.0 TDI Advance MT (110cv) (L11)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 451,
+    "modelo": "Virtus",
+    "versiones": [
+      "1.6 MSI MT (110cv) (L23)",
+      "1.6 MSI Comforline MT (110cv) (L23)",
+      "1.0T 170TSi Highline AT (150cv) (L23)",
+      "1.4T 250TSi Exclusive MT (150cv) (L23)",
+      "1.4 TSi GTS Tiptronic (150cv)",
+      "1.6 MSi Trendline MT (110cv) (L18) 5Ptas.",
+      "1.6 Trendline MT Safety Pack (110cv)",
+      "1.6 MSI Trendline Tiptronic (110cv)",
+      "1.6 Comfortline MT (110cv)",
+      "1.6 Comfortline MT Safety Pack (110cv)",
+      "1.6 Comfortline Tiptronic (110cv)",
+      "1.6 Highline MT (110cv)",
+      "1.6 Highline Tiptronic (110cv)"
+    ]
+  },
+  {
+    "marca": "VOLKSWAGEN",
+    "modeloId": 452,
+    "modelo": "Voyage",
+    "versiones": [
+      "1.6 MSI Trendline (101cv) (L20)",
+      "1.6 MSI Highline (101cv) (L17)",
+      "1.6 Conceptline (101cv) (L08)",
+      "1.6 Advance (101cv) (L08)",
+      "1.6 Trendline / Comfortline (101cv) (MY14 ABG ABS)",
+      "1.6 Comfortline I-Motion (101cv)",
+      "1.6 Comfortline Plus (101cv)",
+      "1.6 Comfortline Plus AB LL (101cv) (MY14 ABG ABS)",
+      "1.6 Comfortline Plus I-Motion ABG ABS LL (101cv)",
+      "1.6 Highline (101cv) (MY14 ABG ABS)",
+      "1.6 Highline I-Motion (101cv)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 768,
+    "modelo": "Buses",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 453,
+    "modelo": "C30",
+    "versiones": [
+      "2.0 MT",
+      "2.0 MT R-Design",
+      "2.0 MT High / Pack (P1) (145hp)",
+      "2.0 MT High Plus / Pack Plus (P2) (145hp)",
+      "2.0 MT High Luxury / Pack Premium (P3) (145hp)",
+      "2.0 AT Pack Plus (P2) (145hp)",
+      "2.4i MT Pack Premium (170hp)",
+      "2.4i AT Pack Plus (170hp)",
+      "2.4i AT Pack Premium (170hp)",
+      "T5 MT Pack Premium (P3) (230cv)",
+      "T5 AT High Luxury / Pack Premium (P3) (230cv)",
+      "T5 MT R-Design (230cv)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 759,
+    "modelo": "FH",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 758,
+    "modelo": "FH Eu5",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 763,
+    "modelo": "FM / FMX",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 761,
+    "modelo": "FM Eu5",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 764,
+    "modelo": "FM11",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 765,
+    "modelo": "FM13",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 762,
+    "modelo": "FMX",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 760,
+    "modelo": "FMX Eu5",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 454,
+    "modelo": "S40",
+    "versiones": [
+      "2.0 MT Pack (P1) (145hp)",
+      "2.0 AT Pack (P1) (145hp)",
+      "2.0 MT Pack Plus (P2) (145hp)",
+      "2.0 AT Pack Plus (P2) (145hp)",
+      "2.4i AT Pack Plus (170hp)",
+      "2.5 T5 MT (230hp)",
+      "2.5 T5 AT High (230hp)",
+      "2.5 T5 AT Pack Premium (230hp)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 455,
+    "modelo": "S60",
+    "versiones": [
+      "2.0T MT High (203cv) (L11)",
+      "2.0T AT High (203cv) (L11)",
+      "2.0T AT Premium (203cv) (L11)",
+      "T4 MT High (180cv) (L12)",
+      "T4 AT High (180cv) (L12)",
+      "T5 AT High Plus (240cv) (L12)",
+      "T5 AT High Plus R-Design (240cv) (L12)",
+      "T5 AT High Luxury (240cv) (L12)",
+      "T6 AT AWD High (304cv) (L12)",
+      "T6 AT AWD High Luxury (304cv) (L12)",
+      "T6 AT AWD R-Desing (304cv) (L12)",
+      "T5 Momentum FWD (254cv) (L16)",
+      "T6 Inscription FWD (320cv) (L16)",
+      "T6 R-Design FWD (320cv) (L16)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 456,
+    "modelo": "S80",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 457,
+    "modelo": "S90",
+    "versiones": [
+      "T6 AWD Inscription"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 458,
+    "modelo": "V40",
+    "versiones": [
+      "T4 1.6T MT High / High Plus (179cv)",
+      "T4 1.6T AT High / High Plus (179cv)",
+      "T4 1.6T MT Plus / High Luxury (179cv)",
+      "T4 1.6T AT Plus / High Luxury (179cv)",
+      "T4 1.6T MT High Luxury City (179cv)",
+      "T4 1.6T AT High Luxury City (179cv)",
+      "T4 2.0T AT Inscription (190cv)",
+      "T4 2.0T AT Momentum (190cv)",
+      "T4 2.0T AT Comfort (190cv)",
+      "Cross Country T4 2.0T 8AT Inscription AWD (190cv)",
+      "Cross Country T4 1.6T MT High (179cv)",
+      "Cross Country T4 1.6T AT High (179cv)",
+      "Cross Country T4 1.6T MT Plus (179cv)",
+      "Cross Country T4 1.6T AT Plus (179cv)",
+      "Cross Country T4 1.6T MT High Plus (179cv)",
+      "Cross Country T4 1.6T AT High Plus (179cv)",
+      "Cross Country T4 1.6T MT High Luxury (179cv)",
+      "Cross Country T4 1.6T AT High Luxury (179cv)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 459,
+    "modelo": "V50",
+    "versiones": [
+      "2.0 MT Pack",
+      "2.4i AT Pack Plus (170hp)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 460,
+    "modelo": "V60",
+    "versiones": [
+      "T6 AT AWD High Luxury",
+      "T6 AT AWD R-Design"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 767,
+    "modelo": "VM",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 766,
+    "modelo": "VM Eu5",
+    "versiones": null
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 461,
+    "modelo": "XC40",
+    "versiones": [
+      "R-Design T5 (1.5 180cv) (E 82cv)",
+      "B4 2.0T (197cv)",
+      "2.0T T4 FWD Kinetic (190hp)",
+      "2.0T T4 FWD Momentum (190hp)",
+      "2.0T T4 AWD Inscription (190hp)",
+      "2.0T T5 AWD Momentum (247hp)",
+      "2.0T T5 AWD R-Design (247hp)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 462,
+    "modelo": "XC60",
+    "versiones": [
+      "T8 Recharge R-Design AWD (2.0T 320cv) (E 88cv)",
+      "B5 AWD (2.0T 249cv)",
+      "2.0 T AT Confort (P0) (203cv)",
+      "2.0 T AT Plus (P0) (203cv)",
+      "T5 2.0T Inscription FWD (240cv)",
+      "T5 2.0T Momentum AWD (247hp) (L17)",
+      "T6 2.0T Inscription AWD (320hp) (L17)",
+      "T5 High (240cv)",
+      "T5 High Plus (240cv)",
+      "T6 AWD High / Plus (304hp)",
+      "T6 AWD High Plus (304hp)",
+      "T6 AWD High Luxury / Premium (304hp)",
+      "T6 AWD High Luxury R-Design (304hp)"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 463,
+    "modelo": "XC70",
+    "versiones": [
+      "3.2 AT / Pack Luxury (238hp)",
+      "T6 AT High Lux"
+    ]
+  },
+  {
+    "marca": "VOLVO",
+    "modeloId": 464,
+    "modelo": "XC90",
+    "versiones": [
+      "T8 II Recharged AWD (2.0T 310cv) (E 91cv) (455cv)",
+      "T8 Recharged AWD (2.0T 320cv) (E 88cv) (408cv)",
+      "D5 2.0 AWD Momentum (235hp)",
+      "D5 2.4 AWD AT High Luxury (200hp) (L13)",
+      "T6 2.0 AWD Inscription (320hp)",
+      "T6 2.9 AWD AT (272hp)",
+      "T6 3.2 AWD AT (235hp)"
+    ]
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs-modules/mailer": "^2.0.2",
+        "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -2627,6 +2628,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
+      "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^2.0.2",
+    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import stripeConfig from './config/stripe.config';
 import { MailModule } from './modules/mail-notification/mailNotification.module';
 import { PricesModule } from './modules/prices/prices.module';
 import { OpenAiModule } from './modules/openai/openai.module';
+import { AcaraScrapingModule } from './modules/acara-scraping/acaraScraping.module';
 
 dotenv.config();
 
@@ -55,6 +56,7 @@ dotenv.config();
     MailModule,
     PricesModule,
     OpenAiModule,
+    AcaraScrapingModule,
   ],
   controllers: [],
   providers: [],

--- a/src/interfaces/vehicleVersion.interface.ts
+++ b/src/interfaces/vehicleVersion.interface.ts
@@ -1,0 +1,4 @@
+export interface VehicleVersion {
+  modelo: string;
+  version: string;
+}

--- a/src/modules/acara-scraping/acaraScraping.controller.ts
+++ b/src/modules/acara-scraping/acaraScraping.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Query, HttpCode } from '@nestjs/common';
+import { AcaraScrapingService } from './acaraScraping.service';
+import { ApiQuery } from '@nestjs/swagger';
+
+@Controller('acara-scraping')
+export class AcaraScrapingController {
+  constructor(private readonly acaraScrapingService: AcaraScrapingService) {}
+
+@Get()
+@HttpCode(200)
+@ApiQuery({ name: 'authToken', required: false, type: String, description: 'Auth token opcional' })
+async scrapeAcara(@Query('authToken') authToken?: string): Promise<any> {
+  return this.acaraScrapingService.scrapeData(authToken);
+}
+}

--- a/src/modules/acara-scraping/acaraScraping.module.ts
+++ b/src/modules/acara-scraping/acaraScraping.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AcaraScrapingController } from './acaraScraping.controller';
+import { AcaraScrapingService } from './acaraScraping.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [AcaraScrapingController],
+  providers: [AcaraScrapingService],
+  exports: [AcaraScrapingService],
+})
+export class AcaraScrapingModule {}

--- a/src/modules/acara-scraping/acaraScraping.service.ts
+++ b/src/modules/acara-scraping/acaraScraping.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import * as cheerio from 'cheerio';
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { VehicleVersion } from '../../interfaces/vehicleVersion.interface';
+
+@Injectable()
+export class AcaraScrapingService {
+  private readonly BASE_URL = 'https://api.acara.org.ar/api/v1/prices';
+  private readonly VEHICULE_TYPE = 1;
+  private readonly DELAY_MS = 5000;
+  private readonly MAX_RETRIES = 3;
+
+  constructor(private readonly httpService: HttpService) {}
+
+  private sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private async fetchWithRetry(url: string, headers: any, retries = this.MAX_RETRIES) {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        const response = await this.httpService.get(url, { headers }).toPromise();
+        return response?.data ?? null;
+      } catch (error) {
+        if (error.response?.status === 429 && attempt < retries) {
+          console.warn(`⚠️  429 Too Many Requests. Reintento ${attempt}/${retries}...`);
+          await this.sleep(this.DELAY_MS * attempt);
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+
+  private async getVehiculeVersions(brandId: number, headers: any): Promise<VehicleVersion[]> {
+    const url = `${this.BASE_URL}/get-vehicules?vehiculeType=${this.VEHICULE_TYPE}&vehiculeBrandId=${brandId}`;
+    try {
+      const response = await this.fetchWithRetry(url, headers);
+      const $ = cheerio.load(response);
+      const rows = $('table tbody tr');
+
+      const versions: VehicleVersion[] = [];
+
+      rows.each((_, row) => {
+        const columns = $(row).find('td');
+        const modelo = $(columns[0]).text().trim();
+        const version = $(columns[1]).text().trim();
+        if (modelo && version) versions.push({ modelo, version });
+      });
+
+      return versions;
+    } catch (error) {
+      console.error(`❌ Error get-vehicules brandId ${brandId}:`, error.message);
+      return [];
+    }
+  }
+
+  async scrapeData(authToken?: string): Promise<any> {
+    const headers = authToken ? { Authorization: authToken } : {};
+    const resultados: { marca: string; modeloId: any; modelo: string; versiones: string[] | null }[] = [];
+
+    try {
+      const brandsResponse = await this.fetchWithRetry(`${this.BASE_URL}/brand-list?vehiculeType=${this.VEHICULE_TYPE}`, headers);
+      const brands = brandsResponse.data ?? [];
+
+      for (const brand of brands) {
+        const brandId = brand.id;
+        const brandName = brand.name;
+        await this.sleep(this.DELAY_MS);
+
+        try {
+          const modelosResponse = await this.fetchWithRetry(`${this.BASE_URL}/model-list?vehiculeType=${this.VEHICULE_TYPE}&vehiculeBrandId=${brandId}`, headers);
+          const modelos = modelosResponse.data ?? [];
+          console.log(`Marca ${brandName} (ID ${brandId}): ${modelos.length} modelos.`);
+
+          const vehiculeVersions = await this.getVehiculeVersions(brandId, headers);
+
+          modelos.forEach(modelo => {
+            const versions = vehiculeVersions
+              .filter(v => v.modelo.toLowerCase() === modelo.name.toLowerCase())
+              .map(v => v.version);
+
+            resultados.push({
+              marca: brandName,
+              modeloId: modelo.id,
+              modelo: modelo.name,
+              versiones: versions.length ? versions : null
+            });
+          });
+        } catch (e) {
+          console.error(`❌ Error model-list brandId ${brandId}:`, e.message);
+        }
+      }
+
+      // ✅ Guardar el archivo en src/assets y sobrescribir si existe
+      const outputDir = join(__dirname, '../../../assets');
+      if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+      }
+      const outputFile = join(outputDir, 'marcas_modelos_versiones_acara.json');
+      writeFileSync(outputFile, JSON.stringify(resultados, null, 2));
+
+      console.log(`✅ Archivo generado en ${outputFile} con ${resultados.length} modelos.`);
+      return resultados;
+
+    } catch (e) {
+      console.error('❌ Error brand-list:', e.message);
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
- Created VehicleVersion interface to define vehicle model and version structure.
- Developed AcaraScrapingController to handle incoming requests and trigger scraping.
- Established AcaraScrapingModule to encapsulate the scraping functionality.
- Implemented AcaraScrapingService with methods to fetch vehicle brands, models, and versions from the Acara API.
- Added error handling and retry logic for API requests.
- Included file writing functionality to save scraped data as JSON.